### PR TITLE
fix: Drawer Body Content get shifted to the right edge

### DIFF
--- a/src/components/drawer/drawer.stories.js
+++ b/src/components/drawer/drawer.stories.js
@@ -219,7 +219,7 @@ const ControlledTemplate = ( args ) => {
 						</Drawer.Description>
 					</Drawer.Header>
 					<Drawer.Body className="overflow-x-hidden">
-						<div className="w-full h-full mx-5 flex items-center justify-center border border-border-subtle border-dashed rounded-md bg-background-secondary">
+						<div className="w-full h-full flex items-center justify-center border border-border-subtle border-dashed rounded-md bg-background-secondary">
 							<p className="m-0 text-text-secondary">
 								Body content
 							</p>
@@ -266,7 +266,7 @@ const UncontrolledTemplate = ( args ) => (
 						</Drawer.Description>
 					</Drawer.Header>
 					<Drawer.Body className="overflow-x-hidden">
-						<div className="w-full h-full mx-5 flex items-center justify-center border border-border-subtle border-dashed rounded-md bg-background-secondary">
+						<div className="w-full h-full flex items-center justify-center border border-border-subtle border-dashed rounded-md bg-background-secondary">
 							<p className="m-0 text-text-secondary">
 								Body content
 							</p>


### PR DESCRIPTION
Removed margin.

### Description

<!-- Please describe what you have changed or added -->

### Screenshots

<!-- if applicable -->

### Types of changes

<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

### Checklist:

-   [ ] My code is tested
-   [ ] My code passes the PHPCS tests
-   [ ] I've created the npm build.
-   [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
-   [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
-   [ ] I've included any necessary tests <!-- if applicable -->
-   [ ] I've included developer documentation <!-- if applicable -->
-   [ ] I've added proper labels to this pull request <!-- if applicable -->
