### PR TITLE
Alignment fixed for Cards

### DIFF
--- a/src/components/cards/list-blocks.stories.tsx
+++ b/src/components/cards/list-blocks.stories.tsx
@@ -90,8 +90,8 @@ const Template3 = () => {
 							className="gap-1 p-1"
 							align="center"
 						>
-							<Container.Item>{ button.icon }</Container.Item>
-							<Container.Item>
+							<Container.Item className="flex">{ button.icon }</Container.Item>
+							<Container.Item className="flex">
 								<a
 									href="#"
 									className="no-underline hover:underline hover:text-field-label"
@@ -101,7 +101,9 @@ const Template3 = () => {
 									</Label>
 								</a>
 							</Container.Item>
-							<Container.Item>{ button.bagde }</Container.Item>
+							{ button.bagde ? (
+								<Container.Item>{ button.bagde }</Container.Item>
+							) : null }
 						</Container>
 					</div>
 				) ) }


### PR DESCRIPTION
### Description

Aligned the cards' inner content.

### Screenshots

https://bsf.d.pr/v/ugNsvO

### Types of changes

Bug fix

### How has this been tested?

https://bsf.d.pr/v/ugNsvO

### Checklist:

-   [x] My code is tested
-   [x] My code passes the PHPCS tests
-   [x] I've created the npm build.
-   [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
-   [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
-   [x] I've included any necessary tests <!-- if applicable -->
-   [x] I've included developer documentation <!-- if applicable -->
-   [ ] I've added proper labels to this pull request <!-- if applicable -->
