### PR TITLE
SUR-358 - fix: z-index of the DropdownMenu component is not overridable

### DIFF
--- a/src/components/dropdown-menu/dropdown-menu.stories.tsx
+++ b/src/components/dropdown-menu/dropdown-menu.stories.tsx
@@ -13,6 +13,7 @@ const meta: Meta<typeof DropdownMenu> = {
 		'DropdownMenu.List': DropdownMenu.List,
 		'DropdownMenu.Item': DropdownMenu.Item,
 		'DropdownMenu.Separator': DropdownMenu.Separator,
+		'DropdownMenu.Portal': DropdownMenu.Portal,
 	} as Record<string, React.ComponentType<unknown>>,
 	parameters: {
 		layout: 'centered',
@@ -34,15 +35,17 @@ export const ButtonTrigger: Story = ( args ) => (
 		<DropdownMenu.Trigger>
 			<Button>Dropdown</Button>
 		</DropdownMenu.Trigger>
-		<DropdownMenu.Content className="w-60">
-			<DropdownMenu.List>
-				<DropdownMenu.Item>Menu Item 1</DropdownMenu.Item>
-				<DropdownMenu.Item>Menu Item 2</DropdownMenu.Item>
-				<DropdownMenu.Item>Menu Item 3</DropdownMenu.Item>
-				<DropdownMenu.Item>Menu Item 4</DropdownMenu.Item>
-				<DropdownMenu.Item>Menu Item 5</DropdownMenu.Item>
-			</DropdownMenu.List>
-		</DropdownMenu.Content>
+		<DropdownMenu.Portal>
+			<DropdownMenu.Content className="w-60">
+				<DropdownMenu.List>
+					<DropdownMenu.Item>Menu Item 1</DropdownMenu.Item>
+					<DropdownMenu.Item>Menu Item 2</DropdownMenu.Item>
+					<DropdownMenu.Item>Menu Item 3</DropdownMenu.Item>
+					<DropdownMenu.Item>Menu Item 4</DropdownMenu.Item>
+					<DropdownMenu.Item>Menu Item 5</DropdownMenu.Item>
+				</DropdownMenu.List>
+			</DropdownMenu.Content>
+		</DropdownMenu.Portal>
 	</DropdownMenu>
 );
 
@@ -52,15 +55,17 @@ export const AvatarTrigger: Story = ( args ) => (
 			<Avatar>John</Avatar>
 			<span className="sr-only">Open Menu</span>
 		</DropdownMenu.Trigger>
-		<DropdownMenu.Content className="w-60">
-			<DropdownMenu.List>
-				<DropdownMenu.Item>Menu Item 1</DropdownMenu.Item>
-				<DropdownMenu.Item>Menu Item 2</DropdownMenu.Item>
-				<DropdownMenu.Item>Menu Item 3</DropdownMenu.Item>
-				<DropdownMenu.Item>Menu Item 4</DropdownMenu.Item>
-				<DropdownMenu.Item>Menu Item 5</DropdownMenu.Item>
-			</DropdownMenu.List>
-		</DropdownMenu.Content>
+		<DropdownMenu.Portal>
+			<DropdownMenu.Content className="w-60">
+				<DropdownMenu.List>
+					<DropdownMenu.Item>Menu Item 1</DropdownMenu.Item>
+					<DropdownMenu.Item>Menu Item 2</DropdownMenu.Item>
+					<DropdownMenu.Item>Menu Item 3</DropdownMenu.Item>
+					<DropdownMenu.Item>Menu Item 4</DropdownMenu.Item>
+					<DropdownMenu.Item>Menu Item 5</DropdownMenu.Item>
+				</DropdownMenu.List>
+			</DropdownMenu.Content>
+		</DropdownMenu.Portal>
 	</DropdownMenu>
 );
 
@@ -70,14 +75,16 @@ export const IconTrigger: Story = ( args ) => (
 			<House />
 			<span className="sr-only">Open Menu</span>
 		</DropdownMenu.Trigger>
-		<DropdownMenu.Content className="w-60">
-			<DropdownMenu.List>
-				<DropdownMenu.Item>Menu Item 1</DropdownMenu.Item>
-				<DropdownMenu.Item>Menu Item 2</DropdownMenu.Item>
-				<DropdownMenu.Item>Menu Item 3</DropdownMenu.Item>
-				<DropdownMenu.Item>Menu Item 4</DropdownMenu.Item>
-				<DropdownMenu.Item>Menu Item 5</DropdownMenu.Item>
-			</DropdownMenu.List>
-		</DropdownMenu.Content>
+		<DropdownMenu.Portal>
+			<DropdownMenu.Content className="w-60">
+				<DropdownMenu.List>
+					<DropdownMenu.Item>Menu Item 1</DropdownMenu.Item>
+					<DropdownMenu.Item>Menu Item 2</DropdownMenu.Item>
+					<DropdownMenu.Item>Menu Item 3</DropdownMenu.Item>
+					<DropdownMenu.Item>Menu Item 4</DropdownMenu.Item>
+					<DropdownMenu.Item>Menu Item 5</DropdownMenu.Item>
+				</DropdownMenu.List>
+			</DropdownMenu.Content>
+		</DropdownMenu.Portal>
 	</DropdownMenu>
 );

--- a/src/components/dropdown-menu/dropdown-types.ts
+++ b/src/components/dropdown-menu/dropdown-types.ts
@@ -42,10 +42,6 @@ export interface DropdownMenuProps extends DropdownCommonProps {
 	offset?: OffsetOptions;
 	/** Defines the boundary of the dropdown menu. */
 	boundary?: Boundary;
-	/** Defines the trigger element of the dropdown menu. */
-	dropdownPortalRoot?: FloatingPortalProps['root'];
-	/** Defines the trigger element of the dropdown menu. */
-	dropdownPortalId?: FloatingPortalProps['id'];
 	/** Additional class name */
 	className?: string;
 }
@@ -59,6 +55,20 @@ export interface DropdownMenuItemProps {
 	onClick?: () => void;
 	/** Additional class name. */
 	className?: string;
+}
+
+export interface DropdownPortalProps extends DropdownCommonProps {
+	/**
+	 * The ID of the portal where the dropdown will be rendered.
+	 * @default undefined
+	 */
+	id?: FloatingPortalProps['id'];
+
+	/**
+	 * The root element where the dropdown will be rendered.
+	 * @default undefined
+	 */
+	root?: FloatingPortalProps['root'];
 }
 
 export type DropdownMenuSeparatorProps = MenuSeparatorProps;


### PR DESCRIPTION
### Description

<!-- Please describe what you have changed or added -->

### Screenshots

<!-- if applicable -->

### Types of changes

<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

### Checklist:

-   [x] My code is tested
-   [ ] My code passes the PHPCS tests
-   [ ] I've created the npm build.
-   [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
-   [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
-   [ ] I've included any necessary tests <!-- if applicable -->
-   [ ] I've included developer documentation <!-- if applicable -->
-   [ ] I've added proper labels to this pull request <!-- if applicable -->
