### PR TITLE
fix: Removed line chart default margin

### DIFF
--- a/src/components/line-chart/line-chart.tsx
+++ b/src/components/line-chart/line-chart.tsx
@@ -76,7 +76,7 @@ interface LineChartProps {
 	 * Line chart Wrapper props.
 	 * @see https://recharts.org/en-US/api/LineChart
 	 */
-	wrapperProps?: Omit<CategoricalChartProps, 'width' | 'height' | 'data'>;
+	lineChartWrapperProps?: Omit<CategoricalChartProps, 'width' | 'height' | 'data'>;
 }
 
 const LineChart = ( {
@@ -98,7 +98,7 @@ const LineChart = ( {
 	chartWidth = 350,
 	chartHeight = 200,
 	withDots = false,
-	wrapperProps,
+	lineChartWrapperProps,
 }: LineChartProps ) => {
 	const defaultColors = [ { stroke: '#2563EB' }, { stroke: '#38BDF8' } ];
 
@@ -122,7 +122,7 @@ const LineChart = ( {
 
 	return (
 		<LineChartWrapper
-			{ ...wrapperProps }
+			{ ...lineChartWrapperProps }
 			width={ chartWidth }
 			height={ chartHeight }
 			data={ data }

--- a/src/components/line-chart/line-chart.tsx
+++ b/src/components/line-chart/line-chart.tsx
@@ -8,6 +8,7 @@ import {
 } from 'recharts';
 import ChartTooltipContent from './chart-tooltip-content';
 import Label from '../label';
+import type { CategoricalChartProps } from 'recharts/types/chart/generateCategoricalChart';
 
 interface DataItem {
 	[key: string]: number | string;
@@ -70,6 +71,12 @@ interface LineChartProps {
 
 	/** Determines whether dots are shown on each data point. */
 	withDots?: boolean;
+
+	/**
+	 * Line chart Wrapper props.
+	 * @see https://recharts.org/en-US/api/LineChart
+	 */
+	wrapperProps?: Omit<CategoricalChartProps, 'width' | 'height' | 'data'>;
 }
 
 const LineChart = ( {
@@ -91,6 +98,7 @@ const LineChart = ( {
 	chartWidth = 350,
 	chartHeight = 200,
 	withDots = false,
+	wrapperProps,
 }: LineChartProps ) => {
 	const defaultColors = [ { stroke: '#2563EB' }, { stroke: '#38BDF8' } ];
 
@@ -114,10 +122,10 @@ const LineChart = ( {
 
 	return (
 		<LineChartWrapper
+			{ ...wrapperProps }
 			width={ chartWidth }
 			height={ chartHeight }
 			data={ data }
-			margin={ { left: 14, right: 14 } }
 		>
 			{ showCartesianGrid && <CartesianGrid vertical={ false } /> }
 			{ showXAxis && (

--- a/src/components/line-chart/line-chart.tsx
+++ b/src/components/line-chart/line-chart.tsx
@@ -73,10 +73,13 @@ interface LineChartProps {
 	withDots?: boolean;
 
 	/**
-	 * Line chart Wrapper props.
+	 * Line chart Wrapper props to apply additional props to the wrapper component. Ex. `margin`, or `onClick` etc.
 	 * @see https://recharts.org/en-US/api/LineChart
 	 */
-	lineChartWrapperProps?: Omit<CategoricalChartProps, 'width' | 'height' | 'data'>;
+	lineChartWrapperProps?: Omit<
+		CategoricalChartProps,
+		'width' | 'height' | 'data'
+	>;
 }
 
 const LineChart = ( {


### PR DESCRIPTION
### Description

<!-- Please describe what you have changed or added -->

### Screenshots

- https://d.pr/i/xs4x9V

### Types of changes

<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

### Checklist:

-   [ ] My code is tested
-   [ ] My code passes the PHPCS tests
-   [ ] I've created the npm build.
-   [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
-   [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
-   [ ] I've included any necessary tests <!-- if applicable -->
-   [ ] I've included developer documentation <!-- if applicable -->
-   [ ] I've added proper labels to this pull request <!-- if applicable -->
