### PR TITLE
SUR-305 - Added Y Axis tick formatter

### DIFF
--- a/src/components/bar-chart/bar-chart.stories.tsx
+++ b/src/components/bar-chart/bar-chart.stories.tsx
@@ -629,10 +629,10 @@ export const BarChartWithAxisFormatters: Story = {
 		docs: {
 			source: {
 				code: `
-import { BarChart } from './bar-chart';
+import { BarChart } from '@bsf/force-ui';
 
-const xTickFormatter = (value: string | number) => value.toString().slice(0, 3);
-const yTickFormatter = (value: number) => \`$\${value}\`;
+const xTickFormatter = (value: string) => value.toString().slice(0, 3);
+const yTickFormatter = (value: string) => \`$\${value}\`;
 
 <BarChart
   data={chartDataMultiple}

--- a/src/components/bar-chart/bar-chart.stories.tsx
+++ b/src/components/bar-chart/bar-chart.stories.tsx
@@ -156,7 +156,7 @@ export const BarChartSimple: Story = {
 		showTooltip: true,
 		tooltipIndicator: 'dot',
 		showCartesianGrid: true,
-		tickFormatter: monthFormatter,
+		xTickFormatter: monthFormatter,
 		yAxisDataKey: 'month',
 	},
 	render: ( args ) => (
@@ -177,7 +177,7 @@ export const BarChartHorizontal: Story = {
 		showYAxis: true,
 		showTooltip: true,
 		showCartesianGrid: false,
-		tickFormatter: monthFormatter,
+		xTickFormatter: monthFormatter,
 		yAxisDataKey: 'month',
 		xAxisFontSize: 'sm',
 		borderRadius: 5,
@@ -196,7 +196,7 @@ export const BarChartMultiple: Story = {
 		tooltipIndicator: 'dashed',
 		tooltipLabelKey: 'month',
 		showCartesianGrid: true,
-		tickFormatter: monthFormatter,
+		xTickFormatter: monthFormatter,
 		xAxisDataKey: 'month',
 		xAxisFontSize: 'sm',
 		borderRadius: 4,
@@ -215,7 +215,7 @@ export const BarChartStucked: Story = {
 		showTooltip: true,
 		showLegend: true,
 		showCartesianGrid: true,
-		tickFormatter: monthFormatter,
+		xTickFormatter: monthFormatter,
 		xAxisDataKey: 'month',
 		xAxisFontSize: 'sm',
 	},
@@ -235,7 +235,7 @@ export const BarChartInteractive: Story = {
 		showTooltip: true,
 		showLegend: false,
 		showCartesianGrid: true,
-		tickFormatter: monthFormatterInteractive,
+		xTickFormatter: monthFormatterInteractive,
 		xAxisDataKey: 'date',
 		xAxisFontSize: 'sm',
 		chartWidth: 900,
@@ -296,7 +296,7 @@ export const BarChartCard1: Story1 = ( args ) => (
 				data={ chartData }
 				dataKeys={ [ 'desktop' ] }
 				showCartesianGrid={ true }
-				tickFormatter={ monthFormatter }
+				xTickFormatter={ monthFormatter }
 				showXAxis={ true }
 				xAxisDataKey="month"
 				showYAxis={ false }
@@ -363,7 +363,7 @@ export const BarChartCard2: Story1 = ( args ) => (
 				showYAxis={ false }
 				showTooltip={ true }
 				showCartesianGrid={ true }
-				tickFormatter={ monthFormatter }
+				xTickFormatter={ monthFormatter }
 				xAxisDataKey="month"
 				borderRadius={ 4 }
 			/>
@@ -430,7 +430,7 @@ export const BarChartCard3: Story1 = ( args ) => (
 				showTooltip={ true }
 				showLegend={ true }
 				showCartesianGrid={ true }
-				tickFormatter={ monthFormatter }
+				xTickFormatter={ monthFormatter }
 				xAxisDataKey="month"
 			/>
 		</Container.Item>
@@ -493,7 +493,7 @@ export const BarChartCard4: Story1 = ( args ) => (
 				showYAxis={ true }
 				showTooltip={ true }
 				showCartesianGrid={ false }
-				tickFormatter={ monthFormatter }
+				xTickFormatter={ monthFormatter }
 				yAxisDataKey="month"
 				xAxisFontSize="sm"
 				borderRadius={ 5 }
@@ -553,7 +553,7 @@ export const AreaChartCard5: Story1 = ( args ) => (
 			<BarChart
 				data={ chartDataIteractive }
 				dataKeys={ [ 'desktop' ] }
-				tickFormatter={ monthFormatterInteractive }
+				xTickFormatter={ monthFormatterInteractive }
 				showXAxis={ true }
 				xAxisDataKey="date"
 				showYAxis={ false }
@@ -578,7 +578,7 @@ export const BarChartCard6: Story = {
 		showTooltip: true,
 		tooltipIndicator: 'dot',
 		showCartesianGrid: true,
-		tickFormatter: monthFormatter,
+		xTickFormatter: monthFormatter,
 		yAxisDataKey: 'month',
 		activeBar: {
 			fill: '#2563EB',

--- a/src/components/bar-chart/bar-chart.stories.tsx
+++ b/src/components/bar-chart/bar-chart.stories.tsx
@@ -599,3 +599,62 @@ export const BarChartCard6: Story = {
 };
 
 BarChartCard6.storyName = 'Customize hover effect';
+
+export const BarChartWithAxisFormatters: Story = {
+	args: {
+		data: chartDataMultiple,
+		dataKeys: [ 'desktop', 'mobile' ],
+		layout: 'horizontal',
+		colors: [ { fill: '#7DD3FC' }, { fill: '#2563EB' } ],
+		showXAxis: true,
+		showYAxis: true,
+		showTooltip: true,
+		tooltipIndicator: 'dot',
+		showCartesianGrid: true,
+		xTickFormatter: monthFormatter,
+		yTickFormatter: ( value: string ) => `$${ value }`,
+		xAxisFontSize: 'md',
+		borderRadius: 4,
+	},
+	render: ( args ) => (
+		<BarChart
+			{ ...args }
+			// Dynamically set axis keys based on layout
+			xAxisDataKey={ args.layout === 'vertical' ? 'desktop' : 'month' }
+			yAxisDataKey={ args.layout === 'vertical' ? 'month' : 'desktop' }
+			showCartesianGrid={ args.layout === 'vertical' ? false : true }
+		/>
+	),
+	parameters: {
+		docs: {
+			source: {
+				code: `
+import { BarChart } from './bar-chart';
+
+const xTickFormatter = (value: string | number) => value.toString().slice(0, 3);
+const yTickFormatter = (value: number) => \`$\${value}\`;
+
+<BarChart
+  data={chartDataMultiple}
+  dataKeys={['desktop', 'mobile']}
+  layout="horizontal"
+  colors={[{ fill: '#7DD3FC' }, { fill: '#2563EB' }]}
+  showXAxis={true}
+  showYAxis={true}
+  showTooltip={true}
+  tooltipIndicator="dot"
+  showCartesianGrid={true}
+  xTickFormatter={xTickFormatter}
+  yTickFormatter={yTickFormatter}
+  xAxisDataKey={layout === 'vertical' ? 'desktop' : 'month'}
+  yAxisDataKey={layout === 'vertical' ? 'month' : 'desktop'}
+  xAxisFontSize="md"
+  borderRadius={4}
+/>;
+        `,
+			},
+		},
+	},
+};
+
+BarChartWithAxisFormatters.storyName = 'Bar Chart with Axis Formatters';

--- a/src/components/bar-chart/bar-chart.tsx
+++ b/src/components/bar-chart/bar-chart.tsx
@@ -58,7 +58,10 @@ interface BarChartProps {
 	showCartesianGrid?: boolean;
 
 	/** A function used to format the ticks on the axes, e.g., ```const monthFormatter = ( value: string ) => value.slice( 0, 3 );``` */
-	tickFormatter?: ( value: string ) => string;
+	xTickFormatter?: ( value: string ) => string;
+
+	/** A function used to format the ticks on the y-axis. */
+	yTickFormatter?: ( value: string ) => string;
 
 	/** The key in the data objects representing values for the x-axis. This is used to access the x-axis values from each data entry. */
 	xAxisDataKey?: string;
@@ -126,7 +129,8 @@ const BarChart = ( {
 	tooltipLabelKey,
 	showLegend = false,
 	showCartesianGrid = true,
-	tickFormatter,
+	xTickFormatter,
+	yTickFormatter,
 	xAxisDataKey,
 	yAxisDataKey,
 	xAxisFontSize = 'sm', // sm, md, lg
@@ -176,7 +180,7 @@ const BarChart = ( {
 						tickLine={ false }
 						axisLine={ false }
 						tickMargin={ 8 }
-						tickFormatter={ tickFormatter }
+						tickFormatter={ xTickFormatter }
 						tick={ {
 							fontSize: fontSizeVariant,
 							fill: xAxisFontColor,
@@ -191,6 +195,7 @@ const BarChart = ( {
 						tickLine={ false }
 						tickMargin={ 10 }
 						axisLine={ false }
+						tickFormatter={ yTickFormatter }
 						tick={ {
 							fontSize: fontSizeVariant,
 							fill: yAxisFontColor,
@@ -213,7 +218,7 @@ const BarChart = ( {
 							tickLine={ false }
 							tickMargin={ 10 }
 							axisLine={ false }
-							tickFormatter={ tickFormatter }
+							tickFormatter={ xTickFormatter }
 							tick={ {
 								fontSize: fontSizeVariant,
 								fill: yAxisFontColor,


### PR DESCRIPTION
### Description

https://d.pr/v/triQSY

You can use Y axis tick formatter like below
```jsx
<BarChart
     yTickFormatter={
           ( value ) => value ? value : 'n/a'     }
/>
```

<!-- Please describe what you have changed or added -->

### Screenshots

<!-- if applicable -->

### Types of changes

<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

### Checklist:

-   [ ] My code is tested
-   [ ] My code passes the PHPCS tests
-   [ ] I've created the npm build.
-   [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
-   [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
-   [ ] I've included any necessary tests <!-- if applicable -->
-   [ ] I've included developer documentation <!-- if applicable -->
-   [ ] I've added proper labels to this pull request <!-- if applicable -->
