### PR TITLE
fix: Showing React.Memo instead of the component name

### DIFF
--- a/src/components/select/select.tsx
+++ b/src/components/select/select.tsx
@@ -12,7 +12,6 @@ import {
 	useLayoutEffect,
 	Fragment,
 	type ReactNode,
-	memo,
 } from 'react';
 import { cn } from '@/utilities/functions';
 import { CheckIcon, ChevronDown, ChevronsUpDown, Search } from 'lucide-react';
@@ -1021,12 +1020,12 @@ const SelectComponent = ( {
 
 SelectComponent.displayName = 'Select';
 
-const Select = Object.assign( memo( SelectComponent ), {
-	Portal: memo( SelectPortal ),
-	Button: memo( SelectButton ),
-	Options: memo( SelectOptions ),
-	Option: memo( SelectItem ),
-	OptionGroup: memo( SelectOptionGroup ),
+const Select = Object.assign( SelectComponent, {
+	Portal: SelectPortal,
+	Button: SelectButton,
+	Options: SelectOptions,
+	Option: SelectItem,
+	OptionGroup: SelectOptionGroup,
 } );
 
 SelectPortal.displayName = 'Select.Portal';


### PR DESCRIPTION
### Description

<!-- Please describe what you have changed or added -->

### Screenshots

<!-- if applicable -->

### Types of changes

<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

### Checklist:

-   [ ] My code is tested
-   [ ] My code passes the PHPCS tests
-   [ ] I've created the npm build.
-   [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
-   [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
-   [ ] I've included any necessary tests <!-- if applicable -->
-   [ ] I've included developer documentation <!-- if applicable -->
-   [ ] I've added proper labels to this pull request <!-- if applicable -->
