### PR TITLE
revert: Font sizes for help text in Switch and Checkbox components

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,4 @@
-
 Version 1.4.2 - xxth February, 2025
-- Improvement - Adjusted the font size of the help text in the Switch and Checkbox component.
 - Improvement - Adjusted the ring width of the Radio Button component.
 
 Version 1.4.1 - 10th February, 2025

--- a/src/components/checkbox/checkbox.tsx
+++ b/src/components/checkbox/checkbox.tsx
@@ -60,18 +60,16 @@ export const CheckboxComponent = (
 			checkbox: 'size-4 rounded gap-1',
 			icon: 'size-3',
 			text: 'text-sm', // text class for sm
+			description: 'text-sm',
 			gap: 'gap-0.5',
 		},
 		md: {
 			checkbox: 'size-5 rounded gap-1',
 			icon: 'size-4',
 			text: 'text-base', // text class for md
+			description: 'text-sm',
 			gap: 'gap-1',
 		},
-	};
-	const descriptionSize = {
-		sm: 'xs',
-		md: 'sm',
 	};
 	const colorClassNames = {
 		primary: {
@@ -136,9 +134,9 @@ export const CheckboxComponent = (
 						tag="p"
 						className={ cn(
 							'font-normal leading-5 m-0',
+							sizeClassNames[ size ].description,
 							disabled && 'text-text-disabled'
 						) }
-						size={ descriptionSize[ size ] as 'xs' | 'sm' }
 						variant="help"
 					>
 						{ label?.description }

--- a/src/components/switch/switch.tsx
+++ b/src/components/switch/switch.tsx
@@ -65,10 +65,9 @@ export const SwitchLabel = ( {
 		sm: 'text-sm leading-5 font-medium',
 		md: 'text-base leading-6 font-medium',
 	};
-	const descriptionSize = {
-		sm: 'xs',
-		md: 'sm',
-		lg: 'sm',
+	const descriptionClasses = {
+		sm: 'text-sm leading-5 font-normal',
+		md: 'text-sm leading-5 font-normal',
 	};
 	const gapClassNames = {
 		sm: 'space-y-0.5',
@@ -102,8 +101,10 @@ export const SwitchLabel = ( {
 					<Label
 						tag="p"
 						variant="help"
-						className="m-0"
-						size={ descriptionSize[ size ] as 'xs' | 'sm' }
+						className={ cn(
+							'text-sm font-normal leading-5 m-0',
+							descriptionClasses[ size ]
+						) }
 						{ ...( disabled && { variant: 'disabled' } ) }
 					>
 						{ description }


### PR DESCRIPTION
### Description

<!-- Please describe what you have changed or added -->

### Screenshots

<!-- if applicable -->

### Types of changes

<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

### Checklist:

-   [ ] My code is tested
-   [ ] My code passes the PHPCS tests
-   [ ] I've created the npm build.
-   [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
-   [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
-   [ ] I've included any necessary tests <!-- if applicable -->
-   [ ] I've included developer documentation <!-- if applicable -->
-   [ ] I've added proper labels to this pull request <!-- if applicable -->
