### PR TITLE
SUR-429, SUR-430, SUR-431 - fix: Gap between label and description of Radio Button

### DIFF
--- a/src/components/radio-button/radio-button.tsx
+++ b/src/components/radio-button/radio-button.tsx
@@ -346,7 +346,16 @@ export const RadioButtonComponent = (
 				) }
 			>
 				{ icon && <>{ icon }</> }
-				<div className={ cn( 'space-y-0.5' ) }>
+				<div
+					className={ cn(
+						! ( icon && useSwitch ) || ( icon && badgeItem )
+							? {
+								'space-y-0.5': size === 'sm',
+								'space-y-1': size === 'md',
+							}
+							: 'space-y-0.5'
+					) }
+				>
 					<p
 						className={ cn(
 							'text-text-primary font-medium m-0',


### PR DESCRIPTION
### Description

<!-- Please describe what you have changed or added -->

### Screenshots

<!-- if applicable -->

### Types of changes

<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

### Checklist:

-   [x] My code is tested
-   [ ] My code passes the PHPCS tests
-   [ ] I've created the npm build.
-   [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
-   [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
-   [ ] I've included any necessary tests <!-- if applicable -->
-   [ ] I've included developer documentation <!-- if applicable -->
-   [ ] I've added proper labels to this pull request <!-- if applicable -->
