### PR TITLE
Tabs and Area chart component improvements

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+Version 1.5.1 - xth x, 2025
+- Improvement - Introduced the `areaChartWrapper` prop in the AreaChart component to allow for better customization options.
+- Improvement - Removed the group selector from the Tabs component to simplify style overrides.
+
 Version 1.5.0 - 14th March, 2025
 - New - Added new Atom, File Preview - to show uploaded file preview.
 - New - Added new variants in Progress Steps component to show icon and number in the completed step.

--- a/src/components/area-chart/area-chart.tsx
+++ b/src/components/area-chart/area-chart.tsx
@@ -12,6 +12,7 @@ import {
 import ChartLegendContent from './chart-legend-content';
 import ChartTooltipContent from './chart-tooltip-content';
 import Label from '../label';
+import type { CategoricalChartProps } from 'recharts/types/chart/generateCategoricalChart';
 
 interface DataItem {
 	[key: string]: number | string; // Adjust based on your data structure
@@ -75,6 +76,15 @@ interface AreaChartProps {
 
 	/** Height of the chart container. */
 	chartHeight?: number;
+
+	/**
+	 * Area chart Wrapper props to apply additional props to the wrapper component. Ex. `margin`, or `onClick` etc.
+	 * @see https://recharts.org/en-US/api/AreaChart
+	 */
+	areaChartWrapperProps?: Omit<
+		CategoricalChartProps,
+		'width' | 'height' | 'data'
+	>;
 }
 
 const AreaChart = ( {
@@ -96,6 +106,14 @@ const AreaChart = ( {
 	xAxisFontColor = '#6B7280',
 	chartWidth = 350,
 	chartHeight = 200,
+	areaChartWrapperProps = {
+		margin: {
+			left: 14,
+			right: 14,
+			top: 6,
+			bottom: 6,
+		},
+	},
 }: AreaChartProps ) => {
 	const [ width, setWidth ] = useState( chartWidth );
 	const [ height, setHeight ] = useState( chartHeight );
@@ -157,7 +175,7 @@ const AreaChart = ( {
 
 	return (
 		<ResponsiveContainer width={ width } height={ height }>
-			<AreaChartWrapper data={ data } margin={ { left: 14, right: 14 } }>
+			<AreaChartWrapper { ...areaChartWrapperProps } data={ data }>
 				{ showCartesianGrid && <CartesianGrid vertical={ false } /> }
 				{ showXAxis && (
 					<XAxis

--- a/src/components/tabs/tabs.tsx
+++ b/src/components/tabs/tabs.tsx
@@ -257,7 +257,7 @@ export const Tab = forwardRef<Ref, TabProps>(
 		}
 
 		// Additional classes.
-		const hoverClasses = 'hover:text-text-primary group';
+		const hoverClasses = 'hover:text-text-primary';
 		const focusClasses = 'focus:outline-none';
 		const disabledClasses = disabled
 			? 'text-text-disabled cursor-not-allowed hover:text-text-disabled'
@@ -281,8 +281,7 @@ export const Tab = forwardRef<Ref, TabProps>(
 		);
 
 		const iconParentClasses = cn(
-			'flex items-center gap-1 group-hover:text-text-primary',
-			disabled && 'group-hover:text-text-disabled'
+			'flex items-center gap-1',
 		);
 
 		// Handle click event.


### PR DESCRIPTION
### Description

```
- Improvement - Introduced the `areaChartWrapper` prop in the AreaChart component to allow for better customization options.
- Improvement - Removed the group selector from the Tabs component to simplify style overrides.
```

### Screenshots

<!-- if applicable -->

### Types of changes

<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

### Checklist:

-   [x] My code is tested
-   [ ] My code passes the PHPCS tests
-   [ ] I've created the npm build.
-   [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
-   [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
-   [ ] I've included any necessary tests <!-- if applicable -->
-   [ ] I've included developer documentation <!-- if applicable -->
-   [ ] I've added proper labels to this pull request <!-- if applicable -->
