### PR TITLE
feat: Next.js (React Server Components) support

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -8,7 +8,7 @@ const __dirname = dirname(__filename);
 
 /** @type { import('@storybook/react-webpack5').StorybookConfig } */
 const config: StorybookConfig = {
-	stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
+	stories: ['../src/**/*.stories.@(js|jsx|mjs|ts|tsx)', '../src/**/*.mdx'],
 	addons: [
 		'@storybook/addon-onboarding',
 		'@storybook/addon-links',
@@ -33,14 +33,50 @@ const config: StorybookConfig = {
 		// Merge custom configuration into the default config
 		const { mergeConfig } = await import('vite');
 
-		// Remove the dts plugin from the default config.
+		// Remove library-build-only plugins that must not run in the Storybook
+		// preview build: vite:dts (type emit) and preserve-directives (which
+		// interferes with MDX's mdx-react-shim import resolution).
+		// Remove library-build-only plugins that must not run in the Storybook
+		// preview build: vite:dts (type emit) and preserve-directives (which
+		// interferes with MDX's mdx-react-shim import resolution).
+		const libOnlyPlugins = [ 'vite:dts', 'preserve-directives' ];
 		config.plugins = [
 			...(config.plugins ?? []).filter((plugin) => {
-				return (
-					(plugin as typeof plugin & Record<string, unknown>).name !==
-					'vite:dts'
-				);
+				const name = (plugin as typeof plugin & Record<string, unknown>)
+					.name as string | undefined;
+				return ! name || ! libOnlyPlugins.includes(name);
 			}),
+		];
+
+		// The library build config (lib mode + externalized devDependencies +
+		// preserveModules output) must not leak into the Storybook preview
+		// build. In particular, externalizing @storybook/addon-docs breaks the
+		// MDX `mdx-react-shim` import. Storybook bundles its own deps, so reset
+		// these to its defaults.
+		if (config.build) {
+			delete config.build.lib;
+			config.build.rollupOptions = {};
+		}
+
+		// Workaround: @storybook/addon-docs emits the MDX runtime shim import as
+		// a malformed `file://./node_modules/...mdx-react-shim.js` specifier,
+		// which Rollup cannot resolve during `build-storybook`. Normalize any
+		// file:// id back to an absolute filesystem path so it resolves.
+		config.plugins = [
+			{
+				name: 'force-ui-normalize-file-url-imports',
+				enforce: 'pre' as const,
+				resolveId(source: string) {
+					if (source.startsWith('file://')) {
+						return path.resolve(
+							process.cwd(),
+							source.slice('file://'.length)
+						);
+					}
+					return null;
+				},
+			},
+			...(config.plugins ?? []),
 		];
 
 		return mergeConfig(config, {

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+Version 1.8.0 - 30th June, 2026
+- New: Added Next.js React Server Components support. Every component now ships the `"use client"` directive in its build output, and compound components additionally expose named subpart exports (e.g. `SelectButton`, `DialogPanel`) so they can be rendered directly inside Server Components.
+
 Version 1.7.13 - 11th June, 2026
 - Fix: Resolved `patch-package: command not found` install failure when the library is consumed as a git dependency. `patch-package` is now a runtime dependency so the bundled Lexical Shadow DOM patches are applied in consumer projects, which is required for the Editor Input mention menu Shadow DOM fix to work.
 

--- a/src/components/accordion/accordion.nextjs.mdx
+++ b/src/components/accordion/accordion.nextjs.mdx
@@ -1,0 +1,51 @@
+import { Meta, Canvas } from '@storybook/addon-docs/blocks';
+import * as Stories from './accordion.stories';
+import * as NextjsStories from './accordion.nextjs.stories';
+
+<Meta of={Stories} name="Next.js Usage" />
+
+# Accordion — Next.js (App Router)
+
+`Accordion` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box and can render inside a **Server Component**.
+
+## Usage in a Server Component
+
+Use the **named subpart exports** — not dot access (`Accordion.X`). In a Server Component, React cannot read sub-components attached to a client reference, so dot access resolves to `undefined`. The named exports are individual client references:
+
+```tsx
+// app/page.tsx — Server Component
+import { Accordion, AccordionItem, AccordionTrigger, AccordionContent } from '@bsf/force-ui';
+
+export default function Page() {
+	return (
+		<Accordion>
+			<AccordionItem value="a">
+				<AccordionTrigger>What is force-ui?</AccordionTrigger>
+				<AccordionContent>A React + Tailwind component library.</AccordionContent>
+			</AccordionItem>
+		</Accordion>
+	);
+}
+```
+
+## Dot notation (client components only)
+
+Inside your own client components the familiar compound dot syntax still works — it is only Server Components that require the named exports above:
+
+```tsx
+'use client';
+import { Accordion } from '@bsf/force-ui';
+
+<Accordion>
+	<Accordion.Item value="a">
+		<Accordion.Trigger>Title</Accordion.Trigger>
+		<Accordion.Content>Body</Accordion.Content>
+	</Accordion.Item>
+</Accordion>
+```
+
+## Live preview
+
+_Rendered with the named (App-Router) pattern. Use **Show code** to copy it._
+
+<Canvas of={NextjsStories.ServerComponentPattern} />

--- a/src/components/accordion/accordion.nextjs.mdx
+++ b/src/components/accordion/accordion.nextjs.mdx
@@ -6,7 +6,7 @@ import * as NextjsStories from './accordion.nextjs.stories';
 
 # Accordion — Next.js (App Router)
 
-`Accordion` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box and can render inside a **Server Component**.
+> **TL;DR** — `Accordion` works in the Next.js App Router out of the box: import it and render it inside a **Server Component**. Use its named subpart exports (e.g. `AccordionItem`) — not dot notation (`Accordion.X`). Put anything interactive (event handlers, state) in a file that starts with `'use client'`.
 
 ## Usage in a Server Component
 
@@ -44,8 +44,24 @@ import { Accordion } from '@bsf/force-ui';
 </Accordion>
 ```
 
+## Event handlers & state
+
+Server Components can't hold state or receive event handlers (`onClick`, `onChange`, …). Move the interactive part into its own client component:
+
+```tsx
+'use client';
+import { Accordion } from '@bsf/force-ui';
+
+export default function Interactive() {
+	// useState, onClick, onChange … live in this client file
+	return <Accordion />;
+}
+```
+
+Then import that into your Server Component — the page itself stays a Server Component.
+
 ## Live preview
 
-_Rendered with the named (App-Router) pattern. Use **Show code** to copy it._
+_Rendered with the named (App-Router) pattern._
 
 <Canvas of={NextjsStories.ServerComponentPattern} />

--- a/src/components/accordion/accordion.nextjs.stories.tsx
+++ b/src/components/accordion/accordion.nextjs.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Accordion, AccordionItem, AccordionTrigger, AccordionContent } from '@/components';
+
+// Powers the "Next.js Usage" docs <Canvas>. Hidden from the sidebar
+// (`!dev`) and excluded from autodocs — it only demonstrates the named
+// (App-Router) import pattern in an isolated preview with copyable code.
+const meta: Meta = {
+	title: 'Molecules/Accordion/Next.js Example',
+	component: Accordion,
+	tags: [ '!dev', '!autodocs' ],
+	parameters: { layout: 'padded' },
+};
+
+export default meta;
+
+export const ServerComponentPattern: StoryObj = {
+	name: 'Named exports (App Router)',
+	render: () => {
+		return (
+			<Accordion>
+				<AccordionItem value="a">
+					<AccordionTrigger>What is force-ui?</AccordionTrigger>
+					<AccordionContent>A React + Tailwind component library.</AccordionContent>
+				</AccordionItem>
+			</Accordion>
+		);
+	},
+};

--- a/src/components/accordion/accordion.nextjs.stories.tsx
+++ b/src/components/accordion/accordion.nextjs.stories.tsx
@@ -8,7 +8,7 @@ const meta: Meta = {
 	title: 'Molecules/Accordion/Next.js Example',
 	component: Accordion,
 	tags: [ '!dev', '!autodocs' ],
-	parameters: { layout: 'padded' },
+	parameters: { layout: 'centered' },
 };
 
 export default meta;
@@ -17,12 +17,14 @@ export const ServerComponentPattern: StoryObj = {
 	name: 'Named exports (App Router)',
 	render: () => {
 		return (
-			<Accordion>
-				<AccordionItem value="a">
-					<AccordionTrigger>What is force-ui?</AccordionTrigger>
-					<AccordionContent>A React + Tailwind component library.</AccordionContent>
-				</AccordionItem>
-			</Accordion>
+			<div className="w-full max-w-lg">
+				<Accordion>
+					<AccordionItem value="a">
+						<AccordionTrigger>What is force-ui?</AccordionTrigger>
+						<AccordionContent>A React + Tailwind component library.</AccordionContent>
+					</AccordionItem>
+				</Accordion>
+			</div>
 		);
 	},
 };

--- a/src/components/accordion/accordion.tsx
+++ b/src/components/accordion/accordion.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React, {
 	type ReactNode,
 	type ElementType,

--- a/src/components/accordion/index.ts
+++ b/src/components/accordion/index.ts
@@ -1,1 +1,6 @@
 export { default } from './accordion';
+export {
+	AccordionItem,
+	AccordionTrigger,
+	AccordionContent,
+} from './accordion';

--- a/src/components/alert/alert.nextjs.mdx
+++ b/src/components/alert/alert.nextjs.mdx
@@ -5,7 +5,7 @@ import * as Stories from './alert.stories';
 
 # Alert — Next.js (App Router)
 
-`Alert` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box. Import it and render it directly inside a **Server Component**.
+> **TL;DR** — `Alert` works in the Next.js App Router out of the box: import it and render it inside a **Server Component**. Put anything interactive (event handlers, state) in a file that starts with `'use client'`.
 
 ## Usage in a Server Component
 
@@ -17,6 +17,22 @@ export default function Page() {
 	return <Alert />;
 }
 ```
+
+## Event handlers & state
+
+Server Components can't hold state or receive event handlers (`onClick`, `onChange`, …). Move the interactive part into its own client component:
+
+```tsx
+'use client';
+import { Alert } from '@bsf/force-ui';
+
+export default function Interactive() {
+	// useState, onClick, onChange … live in this client file
+	return <Alert />;
+}
+```
+
+Then import that into your Server Component — the page itself stays a Server Component.
 
 ## Live preview
 

--- a/src/components/alert/alert.nextjs.mdx
+++ b/src/components/alert/alert.nextjs.mdx
@@ -1,0 +1,23 @@
+import { Meta, Canvas } from '@storybook/addon-docs/blocks';
+import * as Stories from './alert.stories';
+
+<Meta of={Stories} name="Next.js Usage" />
+
+# Alert — Next.js (App Router)
+
+`Alert` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box. Import it and render it directly inside a **Server Component**.
+
+## Usage in a Server Component
+
+```tsx
+// app/page.tsx — Server Component
+import { Alert } from '@bsf/force-ui';
+
+export default function Page() {
+	return <Alert />;
+}
+```
+
+## Live preview
+
+<Canvas of={Stories.Neutral} />

--- a/src/components/alert/alert.tsx
+++ b/src/components/alert/alert.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { cn } from '@/utilities/functions';
 import { getIcon, getAction, getContent, getTitle } from '../toaster/utils';
 import { X } from 'lucide-react';

--- a/src/components/area-chart/area-chart.nextjs.mdx
+++ b/src/components/area-chart/area-chart.nextjs.mdx
@@ -5,7 +5,7 @@ import * as Stories from './area-chart.stories';
 
 # AreaChart — Next.js (App Router)
 
-`AreaChart` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box. Import it and render it directly inside a **Server Component**.
+> **TL;DR** — `AreaChart` works in the Next.js App Router out of the box: import it and render it inside a **Server Component**. Put anything interactive (event handlers, state) in a file that starts with `'use client'`.
 
 ## Usage in a Server Component
 
@@ -21,6 +21,22 @@ export default function Page() {
 ## Notes
 
 - Chart data is passed as props; renders client-side after hydration.
+
+## Event handlers & state
+
+Server Components can't hold state or receive event handlers (`onClick`, `onChange`, …). Move the interactive part into its own client component:
+
+```tsx
+'use client';
+import { AreaChart } from '@bsf/force-ui';
+
+export default function Interactive() {
+	// useState, onClick, onChange … live in this client file
+	return <AreaChart />;
+}
+```
+
+Then import that into your Server Component — the page itself stays a Server Component.
 
 ## Live preview
 

--- a/src/components/area-chart/area-chart.nextjs.mdx
+++ b/src/components/area-chart/area-chart.nextjs.mdx
@@ -1,0 +1,27 @@
+import { Meta, Canvas } from '@storybook/addon-docs/blocks';
+import * as Stories from './area-chart.stories';
+
+<Meta of={Stories} name="Next.js Usage" />
+
+# AreaChart — Next.js (App Router)
+
+`AreaChart` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box. Import it and render it directly inside a **Server Component**.
+
+## Usage in a Server Component
+
+```tsx
+// app/page.tsx — Server Component
+import { AreaChart } from '@bsf/force-ui';
+
+export default function Page() {
+	return <AreaChart />;
+}
+```
+
+## Notes
+
+- Chart data is passed as props; renders client-side after hydration.
+
+## Live preview
+
+<Canvas of={Stories.AreaChartSimple} />

--- a/src/components/area-chart/area-chart.tsx
+++ b/src/components/area-chart/area-chart.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { useEffect, useState, type ReactNode } from 'react';
 import {
 	AreaChart as AreaChartWrapper,

--- a/src/components/avatar/avatar.nextjs.mdx
+++ b/src/components/avatar/avatar.nextjs.mdx
@@ -5,7 +5,7 @@ import * as Stories from './avatar.stories';
 
 # Avatar — Next.js (App Router)
 
-`Avatar` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box. Import it and render it directly inside a **Server Component**.
+> **TL;DR** — `Avatar` works in the Next.js App Router out of the box: import it and render it inside a **Server Component**. Put anything interactive (event handlers, state) in a file that starts with `'use client'`.
 
 ## Usage in a Server Component
 
@@ -17,6 +17,22 @@ export default function Page() {
 	return <Avatar />;
 }
 ```
+
+## Event handlers & state
+
+Server Components can't hold state or receive event handlers (`onClick`, `onChange`, …). Move the interactive part into its own client component:
+
+```tsx
+'use client';
+import { Avatar } from '@bsf/force-ui';
+
+export default function Interactive() {
+	// useState, onClick, onChange … live in this client file
+	return <Avatar />;
+}
+```
+
+Then import that into your Server Component — the page itself stays a Server Component.
 
 ## Live preview
 

--- a/src/components/avatar/avatar.nextjs.mdx
+++ b/src/components/avatar/avatar.nextjs.mdx
@@ -1,0 +1,23 @@
+import { Meta, Canvas } from '@storybook/addon-docs/blocks';
+import * as Stories from './avatar.stories';
+
+<Meta of={Stories} name="Next.js Usage" />
+
+# Avatar — Next.js (App Router)
+
+`Avatar` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box. Import it and render it directly inside a **Server Component**.
+
+## Usage in a Server Component
+
+```tsx
+// app/page.tsx — Server Component
+import { Avatar } from '@bsf/force-ui';
+
+export default function Page() {
+	return <Avatar />;
+}
+```
+
+## Live preview
+
+<Canvas of={Stories.Default} />

--- a/src/components/avatar/avatar.tsx
+++ b/src/components/avatar/avatar.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React, { forwardRef, useEffect, useState, type ReactNode } from 'react';
 import { cn } from '@/utilities/functions';
 import { User } from 'lucide-react';

--- a/src/components/badge/badge.nextjs.mdx
+++ b/src/components/badge/badge.nextjs.mdx
@@ -5,7 +5,7 @@ import * as Stories from './badge.stories';
 
 # Badge — Next.js (App Router)
 
-`Badge` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box. Import it and render it directly inside a **Server Component**.
+> **TL;DR** — `Badge` works in the Next.js App Router out of the box: import it and render it inside a **Server Component**. Put anything interactive (event handlers, state) in a file that starts with `'use client'`.
 
 ## Usage in a Server Component
 
@@ -17,6 +17,22 @@ export default function Page() {
 	return <Badge />;
 }
 ```
+
+## Event handlers & state
+
+Server Components can't hold state or receive event handlers (`onClick`, `onChange`, …). Move the interactive part into its own client component:
+
+```tsx
+'use client';
+import { Badge } from '@bsf/force-ui';
+
+export default function Interactive() {
+	// useState, onClick, onChange … live in this client file
+	return <Badge />;
+}
+```
+
+Then import that into your Server Component — the page itself stays a Server Component.
 
 ## Live preview
 

--- a/src/components/badge/badge.nextjs.mdx
+++ b/src/components/badge/badge.nextjs.mdx
@@ -1,0 +1,23 @@
+import { Meta, Canvas } from '@storybook/addon-docs/blocks';
+import * as Stories from './badge.stories';
+
+<Meta of={Stories} name="Next.js Usage" />
+
+# Badge — Next.js (App Router)
+
+`Badge` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box. Import it and render it directly inside a **Server Component**.
+
+## Usage in a Server Component
+
+```tsx
+// app/page.tsx — Server Component
+import { Badge } from '@bsf/force-ui';
+
+export default function Page() {
+	return <Badge />;
+}
+```
+
+## Live preview
+
+<Canvas of={Stories.Neutral} />

--- a/src/components/badge/badge.tsx
+++ b/src/components/badge/badge.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { forwardRef, type ReactNode } from 'react';
 import { cn } from '@/utilities/functions';
 import { X } from 'lucide-react';

--- a/src/components/bar-chart/bar-chart.nextjs.mdx
+++ b/src/components/bar-chart/bar-chart.nextjs.mdx
@@ -1,0 +1,27 @@
+import { Meta, Canvas } from '@storybook/addon-docs/blocks';
+import * as Stories from './bar-chart.stories';
+
+<Meta of={Stories} name="Next.js Usage" />
+
+# BarChart — Next.js (App Router)
+
+`BarChart` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box. Import it and render it directly inside a **Server Component**.
+
+## Usage in a Server Component
+
+```tsx
+// app/page.tsx — Server Component
+import { BarChart } from '@bsf/force-ui';
+
+export default function Page() {
+	return <BarChart />;
+}
+```
+
+## Notes
+
+- Chart data is passed as props; renders client-side after hydration.
+
+## Live preview
+
+<Canvas of={Stories.BarChartSimple} />

--- a/src/components/bar-chart/bar-chart.nextjs.mdx
+++ b/src/components/bar-chart/bar-chart.nextjs.mdx
@@ -5,7 +5,7 @@ import * as Stories from './bar-chart.stories';
 
 # BarChart — Next.js (App Router)
 
-`BarChart` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box. Import it and render it directly inside a **Server Component**.
+> **TL;DR** — `BarChart` works in the Next.js App Router out of the box: import it and render it inside a **Server Component**. Put anything interactive (event handlers, state) in a file that starts with `'use client'`.
 
 ## Usage in a Server Component
 
@@ -21,6 +21,22 @@ export default function Page() {
 ## Notes
 
 - Chart data is passed as props; renders client-side after hydration.
+
+## Event handlers & state
+
+Server Components can't hold state or receive event handlers (`onClick`, `onChange`, …). Move the interactive part into its own client component:
+
+```tsx
+'use client';
+import { BarChart } from '@bsf/force-ui';
+
+export default function Interactive() {
+	// useState, onClick, onChange … live in this client file
+	return <BarChart />;
+}
+```
+
+Then import that into your Server Component — the page itself stays a Server Component.
 
 ## Live preview
 

--- a/src/components/bar-chart/bar-chart.tsx
+++ b/src/components/bar-chart/bar-chart.tsx
@@ -1,3 +1,4 @@
+'use client';
 import {
 	BarChart as BarChartWrapper,
 	Bar,

--- a/src/components/breadcrumb/breadcrumb.nextjs.mdx
+++ b/src/components/breadcrumb/breadcrumb.nextjs.mdx
@@ -1,0 +1,53 @@
+import { Meta, Canvas } from '@storybook/addon-docs/blocks';
+import * as Stories from './breadcrumb.stories';
+import * as NextjsStories from './breadcrumb.nextjs.stories';
+
+<Meta of={Stories} name="Next.js Usage" />
+
+# Breadcrumb — Next.js (App Router)
+
+`Breadcrumb` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box and can render inside a **Server Component**.
+
+## Usage in a Server Component
+
+Use the **named subpart exports** — not dot access (`Breadcrumb.X`). In a Server Component, React cannot read sub-components attached to a client reference, so dot access resolves to `undefined`. The named exports are individual client references:
+
+```tsx
+// app/page.tsx — Server Component
+import { Breadcrumb, BreadcrumbList, BreadcrumbItem, BreadcrumbLink, BreadcrumbSeparator, BreadcrumbPage } from '@bsf/force-ui';
+
+export default function Page() {
+	return (
+		<Breadcrumb>
+			<BreadcrumbList>
+				<BreadcrumbItem><BreadcrumbLink href="#">Home</BreadcrumbLink></BreadcrumbItem>
+				<BreadcrumbSeparator type="slash" />
+				<BreadcrumbItem><BreadcrumbPage>Current</BreadcrumbPage></BreadcrumbItem>
+			</BreadcrumbList>
+		</Breadcrumb>
+	);
+}
+```
+
+## Dot notation (client components only)
+
+Inside your own client components the familiar compound dot syntax still works — it is only Server Components that require the named exports above:
+
+```tsx
+'use client';
+import { Breadcrumb } from '@bsf/force-ui';
+
+<Breadcrumb>
+	<Breadcrumb.List>
+		<Breadcrumb.Item><Breadcrumb.Link href="#">Home</Breadcrumb.Link></Breadcrumb.Item>
+		<Breadcrumb.Separator type="slash" />
+		<Breadcrumb.Item><Breadcrumb.Page>Current</Breadcrumb.Page></Breadcrumb.Item>
+	</Breadcrumb.List>
+</Breadcrumb>
+```
+
+## Live preview
+
+_Rendered with the named (App-Router) pattern. Use **Show code** to copy it._
+
+<Canvas of={NextjsStories.ServerComponentPattern} />

--- a/src/components/breadcrumb/breadcrumb.nextjs.mdx
+++ b/src/components/breadcrumb/breadcrumb.nextjs.mdx
@@ -6,7 +6,7 @@ import * as NextjsStories from './breadcrumb.nextjs.stories';
 
 # Breadcrumb — Next.js (App Router)
 
-`Breadcrumb` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box and can render inside a **Server Component**.
+> **TL;DR** — `Breadcrumb` works in the Next.js App Router out of the box: import it and render it inside a **Server Component**. Use its named subpart exports (e.g. `BreadcrumbList`) — not dot notation (`Breadcrumb.X`). Put anything interactive (event handlers, state) in a file that starts with `'use client'`.
 
 ## Usage in a Server Component
 
@@ -46,8 +46,24 @@ import { Breadcrumb } from '@bsf/force-ui';
 </Breadcrumb>
 ```
 
+## Event handlers & state
+
+Server Components can't hold state or receive event handlers (`onClick`, `onChange`, …). Move the interactive part into its own client component:
+
+```tsx
+'use client';
+import { Breadcrumb } from '@bsf/force-ui';
+
+export default function Interactive() {
+	// useState, onClick, onChange … live in this client file
+	return <Breadcrumb />;
+}
+```
+
+Then import that into your Server Component — the page itself stays a Server Component.
+
 ## Live preview
 
-_Rendered with the named (App-Router) pattern. Use **Show code** to copy it._
+_Rendered with the named (App-Router) pattern._
 
 <Canvas of={NextjsStories.ServerComponentPattern} />

--- a/src/components/breadcrumb/breadcrumb.nextjs.stories.tsx
+++ b/src/components/breadcrumb/breadcrumb.nextjs.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Breadcrumb, BreadcrumbList, BreadcrumbItem, BreadcrumbLink, BreadcrumbSeparator, BreadcrumbPage } from '@/components';
+
+// Powers the "Next.js Usage" docs <Canvas>. Hidden from the sidebar
+// (`!dev`) and excluded from autodocs — it only demonstrates the named
+// (App-Router) import pattern in an isolated preview with copyable code.
+const meta: Meta = {
+	title: 'Atoms/Breadcrumb/Next.js Example',
+	component: Breadcrumb,
+	tags: [ '!dev', '!autodocs' ],
+	parameters: { layout: 'padded' },
+};
+
+export default meta;
+
+export const ServerComponentPattern: StoryObj = {
+	name: 'Named exports (App Router)',
+	render: () => {
+		return (
+			<Breadcrumb>
+				<BreadcrumbList>
+					<BreadcrumbItem><BreadcrumbLink href="#">Home</BreadcrumbLink></BreadcrumbItem>
+					<BreadcrumbSeparator type="slash" />
+					<BreadcrumbItem><BreadcrumbPage>Current</BreadcrumbPage></BreadcrumbItem>
+				</BreadcrumbList>
+			</Breadcrumb>
+		);
+	},
+};

--- a/src/components/breadcrumb/breadcrumb.nextjs.stories.tsx
+++ b/src/components/breadcrumb/breadcrumb.nextjs.stories.tsx
@@ -8,7 +8,7 @@ const meta: Meta = {
 	title: 'Atoms/Breadcrumb/Next.js Example',
 	component: Breadcrumb,
 	tags: [ '!dev', '!autodocs' ],
-	parameters: { layout: 'padded' },
+	parameters: { layout: 'centered' },
 };
 
 export default meta;

--- a/src/components/breadcrumb/breadcrumb.tsx
+++ b/src/components/breadcrumb/breadcrumb.tsx
@@ -1,3 +1,4 @@
+'use client';
 import {
 	createContext,
 	useContext,

--- a/src/components/breadcrumb/index.ts
+++ b/src/components/breadcrumb/index.ts
@@ -1,1 +1,9 @@
 export { default } from './breadcrumb';
+export {
+	BreadcrumbList,
+	BreadcrumbItem,
+	BreadcrumbLink,
+	BreadcrumbSeparator,
+	BreadcrumbEllipsis,
+	BreadcrumbPage,
+} from './breadcrumb';

--- a/src/components/button-group/button-group.nextjs.mdx
+++ b/src/components/button-group/button-group.nextjs.mdx
@@ -1,0 +1,55 @@
+import { Meta, Canvas } from '@storybook/addon-docs/blocks';
+import * as NextjsStories from './button-group.nextjs.stories';
+
+<Meta title="Atoms/ButtonGroup/Next.js Usage" />
+
+# ButtonGroup — Next.js (App Router)
+
+> **TL;DR** — `ButtonGroup` works in the Next.js App Router out of the box. In a **Server Component**, use its named exports (`ButtonGroupContainer`, `ButtonGroupButton`) — not dot notation (`ButtonGroup.Group` / `ButtonGroup.Button`). Put anything interactive (event handlers, state) in a file that starts with `'use client'`.
+
+## Usage in a Server Component
+
+`ButtonGroup` is a compound component exposed as an object (`ButtonGroup.Group`, `ButtonGroup.Button`). Dot access doesn't work in a Server Component — React can't read those sub-components across the client boundary, so they resolve to `undefined`. Import the named exports instead:
+
+```tsx
+// app/view-toggle.tsx
+'use client';
+import { useState } from 'react';
+import { ButtonGroupContainer, ButtonGroupButton } from '@bsf/force-ui';
+
+export default function ViewToggle() {
+	const [ active, setActive ] = useState( 'list' );
+	return (
+		<ButtonGroupContainer activeItem={ active } onChange={ ( { value } ) => setActive( value.slug ) }>
+			<ButtonGroupButton slug="list" text="List" />
+			<ButtonGroupButton slug="grid" text="Grid" />
+		</ButtonGroupContainer>
+	);
+}
+```
+
+> `ButtonGroup.Group` is exported as **`ButtonGroupContainer`** and `ButtonGroup.Button` as **`ButtonGroupButton`**.
+
+## Dot notation (client components only)
+
+Inside your own client components the compound dot syntax still works — it is only Server Components that require the named exports above:
+
+```tsx
+'use client';
+import { ButtonGroup } from '@bsf/force-ui';
+
+<ButtonGroup.Group activeItem={ active } onChange={ handleChange }>
+	<ButtonGroup.Button slug="list" text="List" />
+	<ButtonGroup.Button slug="grid" text="Grid" />
+</ButtonGroup.Group>
+```
+
+## Notes
+
+- The `activeItem` / `onChange` state must live in a client component.
+
+## Live preview
+
+_Rendered with the named (App-Router) pattern._
+
+<Canvas of={NextjsStories.ServerComponentPattern} />

--- a/src/components/button-group/button-group.nextjs.stories.tsx
+++ b/src/components/button-group/button-group.nextjs.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+import { ButtonGroupContainer, ButtonGroupButton } from '@/components';
+
+// Powers the "Next.js Usage" docs <Canvas>. Hidden from the sidebar (`!dev`)
+// and excluded from autodocs — it only demonstrates the named (App-Router)
+// import pattern in an isolated preview.
+const meta: Meta = {
+	title: 'Atoms/ButtonGroup/Next.js Example',
+	component: ButtonGroupContainer,
+	tags: [ '!dev', '!autodocs' ],
+	parameters: { layout: 'centered' },
+};
+
+export default meta;
+
+export const ServerComponentPattern: StoryObj = {
+	name: 'Named exports (App Router)',
+	render: () => {
+		// eslint-disable-next-line react-hooks/rules-of-hooks
+		const [ active, setActive ] = useState( 'list' );
+		return (
+			<ButtonGroupContainer
+				activeItem={ active }
+				onChange={ ( { value } ) => setActive( value.slug ) }
+			>
+				<ButtonGroupButton slug="list" text="List" />
+				<ButtonGroupButton slug="grid" text="Grid" />
+			</ButtonGroupContainer>
+		);
+	},
+};

--- a/src/components/button-group/button-group.tsx
+++ b/src/components/button-group/button-group.tsx
@@ -212,4 +212,11 @@ const exports = {
 	Button,
 };
 
+// Named exports for React Server Components: dot access (`ButtonGroup.Group` /
+// `ButtonGroup.Button`) can't cross the RSC client boundary, so expose each
+// part as its own named export. The default compound object is kept for
+// backward-compatible dot usage inside client components.
+export const ButtonGroupContainer = ButtonGroup;
+export const ButtonGroupButton = Button;
+
 export default exports;

--- a/src/components/button-group/button-group.tsx
+++ b/src/components/button-group/button-group.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React, {
 	useCallback,
 	forwardRef,

--- a/src/components/button-group/index.ts
+++ b/src/components/button-group/index.ts
@@ -1,1 +1,2 @@
 export { default } from './button-group';
+export { ButtonGroupContainer, ButtonGroupButton } from './button-group';

--- a/src/components/button/button.nextjs.mdx
+++ b/src/components/button/button.nextjs.mdx
@@ -1,0 +1,23 @@
+import { Meta, Canvas } from '@storybook/addon-docs/blocks';
+import * as Stories from './button.stories';
+
+<Meta of={Stories} name="Next.js Usage" />
+
+# Button — Next.js (App Router)
+
+`Button` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box. Import it and render it directly inside a **Server Component**.
+
+## Usage in a Server Component
+
+```tsx
+// app/page.tsx — Server Component
+import { Button } from '@bsf/force-ui';
+
+export default function Page() {
+	return <Button />;
+}
+```
+
+## Live preview
+
+<Canvas of={Stories.Default} />

--- a/src/components/button/button.nextjs.mdx
+++ b/src/components/button/button.nextjs.mdx
@@ -5,7 +5,7 @@ import * as Stories from './button.stories';
 
 # Button — Next.js (App Router)
 
-`Button` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box. Import it and render it directly inside a **Server Component**.
+> **TL;DR** — `Button` works in the Next.js App Router out of the box: import it and render it inside a **Server Component**. Put anything interactive (event handlers, state) in a file that starts with `'use client'`.
 
 ## Usage in a Server Component
 
@@ -17,6 +17,22 @@ export default function Page() {
 	return <Button />;
 }
 ```
+
+## Event handlers & state
+
+Server Components can't hold state or receive event handlers (`onClick`, `onChange`, …). Move the interactive part into its own client component:
+
+```tsx
+'use client';
+import { Button } from '@bsf/force-ui';
+
+export default function Interactive() {
+	// useState, onClick, onChange … live in this client file
+	return <Button />;
+}
+```
+
+Then import that into your Server Component — the page itself stays a Server Component.
 
 ## Live preview
 

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React, {
 	forwardRef,
 	Fragment,

--- a/src/components/checkbox/checkbox.nextjs.mdx
+++ b/src/components/checkbox/checkbox.nextjs.mdx
@@ -1,0 +1,27 @@
+import { Meta, Canvas } from '@storybook/addon-docs/blocks';
+import * as Stories from './checkbox.stories';
+
+<Meta of={Stories} name="Next.js Usage" />
+
+# Checkbox — Next.js (App Router)
+
+`Checkbox` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box. Import it and render it directly inside a **Server Component**.
+
+## Usage in a Server Component
+
+```tsx
+// app/page.tsx — Server Component
+import { Checkbox } from '@bsf/force-ui';
+
+export default function Page() {
+	return <Checkbox />;
+}
+```
+
+## Notes
+
+- Value/`onChange` handlers must be defined in a client component.
+
+## Live preview
+
+<Canvas of={Stories.Small} />

--- a/src/components/checkbox/checkbox.nextjs.mdx
+++ b/src/components/checkbox/checkbox.nextjs.mdx
@@ -5,7 +5,7 @@ import * as Stories from './checkbox.stories';
 
 # Checkbox — Next.js (App Router)
 
-`Checkbox` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box. Import it and render it directly inside a **Server Component**.
+> **TL;DR** — `Checkbox` works in the Next.js App Router out of the box: import it and render it inside a **Server Component**. Put anything interactive (event handlers, state) in a file that starts with `'use client'`.
 
 ## Usage in a Server Component
 
@@ -21,6 +21,22 @@ export default function Page() {
 ## Notes
 
 - Value/`onChange` handlers must be defined in a client component.
+
+## Event handlers & state
+
+Server Components can't hold state or receive event handlers (`onClick`, `onChange`, …). Move the interactive part into its own client component:
+
+```tsx
+'use client';
+import { Checkbox } from '@bsf/force-ui';
+
+export default function Interactive() {
+	// useState, onClick, onChange … live in this client file
+	return <Checkbox />;
+}
+```
+
+Then import that into your Server Component — the page itself stays a Server Component.
 
 ## Live preview
 

--- a/src/components/checkbox/checkbox.tsx
+++ b/src/components/checkbox/checkbox.tsx
@@ -1,3 +1,4 @@
+'use client';
 import {
 	useState,
 	useCallback,

--- a/src/components/container/container.nextjs.mdx
+++ b/src/components/container/container.nextjs.mdx
@@ -1,0 +1,48 @@
+import { Meta, Canvas } from '@storybook/addon-docs/blocks';
+import * as Stories from './container.stories';
+import * as NextjsStories from './container.nextjs.stories';
+
+<Meta of={Stories} name="Next.js Usage" />
+
+# Container — Next.js (App Router)
+
+`Container` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box and can render inside a **Server Component**.
+
+## Usage in a Server Component
+
+Use the **named subpart exports** — not dot access (`Container.X`). In a Server Component, React cannot read sub-components attached to a client reference, so dot access resolves to `undefined`. The named exports are individual client references:
+
+```tsx
+// app/page.tsx — Server Component
+import { Container, ContainerItem } from '@bsf/force-ui';
+
+export default function Page() {
+	return (
+		<Container>
+			<ContainerItem>Item A</ContainerItem>
+			<ContainerItem>Item B</ContainerItem>
+		</Container>
+	);
+}
+```
+
+> `Container.Item` is exported as **`ContainerItem`**.
+
+## Dot notation (client components only)
+
+Inside your own client components the familiar compound dot syntax still works — it is only Server Components that require the named exports above:
+
+```tsx
+'use client';
+import { Container } from '@bsf/force-ui';
+
+<Container>
+	<Container.Item>Item A</Container.Item>
+</Container>
+```
+
+## Live preview
+
+_Rendered with the named (App-Router) pattern. Use **Show code** to copy it._
+
+<Canvas of={NextjsStories.ServerComponentPattern} />

--- a/src/components/container/container.nextjs.mdx
+++ b/src/components/container/container.nextjs.mdx
@@ -6,7 +6,7 @@ import * as NextjsStories from './container.nextjs.stories';
 
 # Container — Next.js (App Router)
 
-`Container` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box and can render inside a **Server Component**.
+> **TL;DR** — `Container` works in the Next.js App Router out of the box: import it and render it inside a **Server Component**. Use its named subpart exports (e.g. `ContainerItem`) — not dot notation (`Container.X`). Put anything interactive (event handlers, state) in a file that starts with `'use client'`.
 
 ## Usage in a Server Component
 
@@ -41,8 +41,24 @@ import { Container } from '@bsf/force-ui';
 </Container>
 ```
 
+## Event handlers & state
+
+Server Components can't hold state or receive event handlers (`onClick`, `onChange`, …). Move the interactive part into its own client component:
+
+```tsx
+'use client';
+import { Container } from '@bsf/force-ui';
+
+export default function Interactive() {
+	// useState, onClick, onChange … live in this client file
+	return <Container />;
+}
+```
+
+Then import that into your Server Component — the page itself stays a Server Component.
+
 ## Live preview
 
-_Rendered with the named (App-Router) pattern. Use **Show code** to copy it._
+_Rendered with the named (App-Router) pattern._
 
 <Canvas of={NextjsStories.ServerComponentPattern} />

--- a/src/components/container/container.nextjs.stories.tsx
+++ b/src/components/container/container.nextjs.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Container, ContainerItem } from '@/components';
+
+// Powers the "Next.js Usage" docs <Canvas>. Hidden from the sidebar
+// (`!dev`) and excluded from autodocs — it only demonstrates the named
+// (App-Router) import pattern in an isolated preview with copyable code.
+const meta: Meta = {
+	title: 'Atoms/Container/Next.js Example',
+	component: Container,
+	tags: [ '!dev', '!autodocs' ],
+	parameters: { layout: 'padded' },
+};
+
+export default meta;
+
+export const ServerComponentPattern: StoryObj = {
+	name: 'Named exports (App Router)',
+	render: () => {
+		return (
+			<Container>
+				<ContainerItem>Item A</ContainerItem>
+				<ContainerItem>Item B</ContainerItem>
+			</Container>
+		);
+	},
+};

--- a/src/components/container/container.nextjs.stories.tsx
+++ b/src/components/container/container.nextjs.stories.tsx
@@ -8,7 +8,7 @@ const meta: Meta = {
 	title: 'Atoms/Container/Next.js Example',
 	component: Container,
 	tags: [ '!dev', '!autodocs' ],
-	parameters: { layout: 'padded' },
+	parameters: { layout: 'centered' },
 };
 
 export default meta;

--- a/src/components/container/container.tsx
+++ b/src/components/container/container.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { createContext, useContext } from 'react';
 import { cn } from '@/utilities/functions';
 import GridContainer from './grid-container';

--- a/src/components/container/index.ts
+++ b/src/components/container/index.ts
@@ -1,1 +1,4 @@
 export { default } from './container';
+export {
+	Item as ContainerItem,
+} from './container';

--- a/src/components/datepicker/datepicker.nextjs.mdx
+++ b/src/components/datepicker/datepicker.nextjs.mdx
@@ -1,0 +1,27 @@
+import { Meta, Canvas } from '@storybook/addon-docs/blocks';
+import * as Stories from './datepicker.stories';
+
+<Meta of={Stories} name="Next.js Usage" />
+
+# DatePicker — Next.js (App Router)
+
+`DatePicker` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box. Import it and render it directly inside a **Server Component**.
+
+## Usage in a Server Component
+
+```tsx
+// app/page.tsx — Server Component
+import { DatePicker } from '@bsf/force-ui';
+
+export default function Page() {
+	return <DatePicker />;
+}
+```
+
+## Notes
+
+- Value/`onChange` handlers must be defined in a client component.
+
+## Live preview
+
+<Canvas of={Stories.Default} />

--- a/src/components/datepicker/datepicker.nextjs.mdx
+++ b/src/components/datepicker/datepicker.nextjs.mdx
@@ -5,7 +5,7 @@ import * as Stories from './datepicker.stories';
 
 # DatePicker — Next.js (App Router)
 
-`DatePicker` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box. Import it and render it directly inside a **Server Component**.
+> **TL;DR** — `DatePicker` works in the Next.js App Router out of the box: import it and render it inside a **Server Component**. Put anything interactive (event handlers, state) in a file that starts with `'use client'`.
 
 ## Usage in a Server Component
 
@@ -21,6 +21,22 @@ export default function Page() {
 ## Notes
 
 - Value/`onChange` handlers must be defined in a client component.
+
+## Event handlers & state
+
+Server Components can't hold state or receive event handlers (`onClick`, `onChange`, …). Move the interactive part into its own client component:
+
+```tsx
+'use client';
+import { DatePicker } from '@bsf/force-ui';
+
+export default function Interactive() {
+	// useState, onClick, onChange … live in this client file
+	return <DatePicker />;
+}
+```
+
+Then import that into your Server Component — the page itself stays a Server Component.
 
 ## Live preview
 

--- a/src/components/datepicker/datepicker.tsx
+++ b/src/components/datepicker/datepicker.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { useState } from 'react';
 import DatePickerComponent, { TDateRange } from './datepicker-component';
 import Button from '../button';

--- a/src/components/dialog/dialog.nextjs.mdx
+++ b/src/components/dialog/dialog.nextjs.mdx
@@ -1,0 +1,66 @@
+import { Meta, Canvas } from '@storybook/addon-docs/blocks';
+import * as Stories from './dialog.stories';
+import * as NextjsStories from './dialog.nextjs.stories';
+
+<Meta of={Stories} name="Next.js Usage" />
+
+# Dialog — Next.js (App Router)
+
+`Dialog` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box and can render inside a **Server Component**.
+
+## Usage in a Server Component
+
+Use the **named subpart exports** — not dot access (`Dialog.X`). In a Server Component, React cannot read sub-components attached to a client reference, so dot access resolves to `undefined`. The named exports are individual client references:
+
+```tsx
+// app/dialog-demo.tsx
+'use client';
+import { useState } from 'react';
+import { Dialog, DialogPanel, DialogHeader, DialogTitle, DialogBody, DialogFooter, DialogCloseButton, DialogBackdrop, Button } from '@bsf/force-ui';
+
+export default function Demo() {
+	const [ open, setOpen ] = useState( false );
+	return (
+		<Dialog open={ open } setOpen={ setOpen } trigger={ <Button>Open Dialog</Button> }>
+			<DialogBackdrop />
+			<DialogPanel>
+				<DialogHeader>
+					<DialogTitle>Dialog Title</DialogTitle>
+					<DialogCloseButton />
+				</DialogHeader>
+				<DialogBody>Dialog body content.</DialogBody>
+				<DialogFooter>
+					<Button onClick={ () => setOpen( false ) }>Close</Button>
+				</DialogFooter>
+			</DialogPanel>
+		</Dialog>
+	);
+}
+```
+
+## Dot notation (client components only)
+
+Inside your own client components the familiar compound dot syntax still works — it is only Server Components that require the named exports above:
+
+```tsx
+'use client';
+import { Dialog } from '@bsf/force-ui';
+
+<Dialog open={ open } setOpen={ setOpen }>
+	<Dialog.Backdrop />
+	<Dialog.Panel>
+		<Dialog.Header><Dialog.Title>Title</Dialog.Title><Dialog.CloseButton /></Dialog.Header>
+		<Dialog.Body>Body</Dialog.Body>
+	</Dialog.Panel>
+</Dialog>
+```
+
+## Notes
+
+- Open state (`open` / `setOpen`) and any `trigger` handler live in a client component.
+
+## Live preview
+
+_Rendered with the named (App-Router) pattern. Use **Show code** to copy it._
+
+<Canvas of={NextjsStories.ServerComponentPattern} />

--- a/src/components/dialog/dialog.nextjs.mdx
+++ b/src/components/dialog/dialog.nextjs.mdx
@@ -6,7 +6,7 @@ import * as NextjsStories from './dialog.nextjs.stories';
 
 # Dialog — Next.js (App Router)
 
-`Dialog` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box and can render inside a **Server Component**.
+> **TL;DR** — `Dialog` works in the Next.js App Router out of the box: import it and render it inside a **Server Component**. Use its named subpart exports (e.g. `DialogPanel`) — not dot notation (`Dialog.X`). Put anything interactive (event handlers, state) in a file that starts with `'use client'`.
 
 ## Usage in a Server Component
 
@@ -25,8 +25,10 @@ export default function Demo() {
 			<DialogBackdrop />
 			<DialogPanel>
 				<DialogHeader>
-					<DialogTitle>Dialog Title</DialogTitle>
-					<DialogCloseButton />
+					<div className="flex items-center justify-between">
+						<DialogTitle>Dialog Title</DialogTitle>
+						<DialogCloseButton />
+					</div>
 				</DialogHeader>
 				<DialogBody>Dialog body content.</DialogBody>
 				<DialogFooter>
@@ -61,6 +63,6 @@ import { Dialog } from '@bsf/force-ui';
 
 ## Live preview
 
-_Rendered with the named (App-Router) pattern. Use **Show code** to copy it._
+_Rendered with the named (App-Router) pattern._
 
 <Canvas of={NextjsStories.ServerComponentPattern} />

--- a/src/components/dialog/dialog.nextjs.stories.tsx
+++ b/src/components/dialog/dialog.nextjs.stories.tsx
@@ -9,7 +9,7 @@ const meta: Meta = {
 	title: 'Organisms/Dialog/Next.js Example',
 	component: Dialog,
 	tags: [ '!dev', '!autodocs' ],
-	parameters: { layout: 'padded' },
+	parameters: { layout: 'fullscreen' },
 };
 
 export default meta;
@@ -20,19 +20,23 @@ export const ServerComponentPattern: StoryObj = {
 		// eslint-disable-next-line react-hooks/rules-of-hooks
 		const [ open, setOpen ] = useState( false );
 		return (
-			<Dialog open={ open } setOpen={ setOpen } trigger={ <Button>Open Dialog</Button> }>
-				<DialogBackdrop />
-				<DialogPanel>
-					<DialogHeader>
-						<DialogTitle>Dialog Title</DialogTitle>
-						<DialogCloseButton />
-					</DialogHeader>
-					<DialogBody>Dialog body content.</DialogBody>
-					<DialogFooter>
-						<Button onClick={ () => setOpen( false ) }>Close</Button>
-					</DialogFooter>
-				</DialogPanel>
-			</Dialog>
+			<div className="h-[460px] flex items-center justify-center">
+				<Dialog open={ open } setOpen={ setOpen } trigger={ <Button>Open Dialog</Button> }>
+					<DialogBackdrop />
+					<DialogPanel>
+						<DialogHeader>
+							<div className="flex items-center justify-between">
+								<DialogTitle>Dialog Title</DialogTitle>
+								<DialogCloseButton />
+							</div>
+						</DialogHeader>
+						<DialogBody>Dialog body content.</DialogBody>
+						<DialogFooter>
+							<Button onClick={ () => setOpen( false ) }>Close</Button>
+						</DialogFooter>
+					</DialogPanel>
+				</Dialog>
+			</div>
 		);
 	},
 };

--- a/src/components/dialog/dialog.nextjs.stories.tsx
+++ b/src/components/dialog/dialog.nextjs.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+import { Dialog, DialogPanel, DialogHeader, DialogTitle, DialogBody, DialogFooter, DialogCloseButton, DialogBackdrop, Button } from '@/components';
+
+// Powers the "Next.js Usage" docs <Canvas>. Hidden from the sidebar
+// (`!dev`) and excluded from autodocs — it only demonstrates the named
+// (App-Router) import pattern in an isolated preview with copyable code.
+const meta: Meta = {
+	title: 'Organisms/Dialog/Next.js Example',
+	component: Dialog,
+	tags: [ '!dev', '!autodocs' ],
+	parameters: { layout: 'padded' },
+};
+
+export default meta;
+
+export const ServerComponentPattern: StoryObj = {
+	name: 'Named exports (App Router)',
+	render: () => {
+		// eslint-disable-next-line react-hooks/rules-of-hooks
+		const [ open, setOpen ] = useState( false );
+		return (
+			<Dialog open={ open } setOpen={ setOpen } trigger={ <Button>Open Dialog</Button> }>
+				<DialogBackdrop />
+				<DialogPanel>
+					<DialogHeader>
+						<DialogTitle>Dialog Title</DialogTitle>
+						<DialogCloseButton />
+					</DialogHeader>
+					<DialogBody>Dialog body content.</DialogBody>
+					<DialogFooter>
+						<Button onClick={ () => setOpen( false ) }>Close</Button>
+					</DialogFooter>
+				</DialogPanel>
+			</Dialog>
+		);
+	},
+};

--- a/src/components/dialog/dialog.tsx
+++ b/src/components/dialog/dialog.tsx
@@ -1,3 +1,4 @@
+'use client';
 import {
 	cloneElement,
 	createContext,

--- a/src/components/dialog/index.ts
+++ b/src/components/dialog/index.ts
@@ -1,1 +1,12 @@
 export { default } from './dialog';
+export {
+	DialogPanel,
+	DialogPortal,
+	DialogTitle,
+	DialogDescription,
+	DialogCloseButton,
+	DialogHeader,
+	DialogBody,
+	DialogFooter,
+	DialogBackdrop,
+} from './dialog';

--- a/src/components/drawer/drawer-backdrop.tsx
+++ b/src/components/drawer/drawer-backdrop.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { AnimatePresence, motion } from 'framer-motion';
 import { useDrawerState } from './drawer';
 import { createPortal } from 'react-dom';

--- a/src/components/drawer/drawer-body.tsx
+++ b/src/components/drawer/drawer-body.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { cn } from '@/utilities/functions';
 import { type ReactNode } from 'react';
 

--- a/src/components/drawer/drawer-close-button.tsx
+++ b/src/components/drawer/drawer-close-button.tsx
@@ -1,3 +1,4 @@
+'use client';
 import {
 	cloneElement,
 	type ElementType,

--- a/src/components/drawer/drawer-description.tsx
+++ b/src/components/drawer/drawer-description.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { cn } from '@/utilities/functions';
 import { type ElementType, type ReactNode, useEffect } from 'react';
 import { useDrawerState } from './drawer';

--- a/src/components/drawer/drawer-footer.tsx
+++ b/src/components/drawer/drawer-footer.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { cn } from '@/utilities/functions';
 import { useDrawerState } from './drawer';
 import { type ReactNode } from 'react';

--- a/src/components/drawer/drawer-header.tsx
+++ b/src/components/drawer/drawer-header.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { cn } from '@/utilities/functions';
 import { type ReactNode } from 'react';
 

--- a/src/components/drawer/drawer-panel.tsx
+++ b/src/components/drawer/drawer-panel.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { type ReactNode } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
 import { useDrawerState } from './drawer';

--- a/src/components/drawer/drawer-portal.tsx
+++ b/src/components/drawer/drawer-portal.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { FloatingPortal } from '@floating-ui/react';
 import type { ReactNode } from 'react';
 

--- a/src/components/drawer/drawer-title.tsx
+++ b/src/components/drawer/drawer-title.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { type ReactNode, type ElementType, useEffect } from 'react';
 import { cn } from '@/utilities/functions';
 import { useDrawerState } from './drawer';

--- a/src/components/drawer/drawer.nextjs.mdx
+++ b/src/components/drawer/drawer.nextjs.mdx
@@ -6,7 +6,7 @@ import * as NextjsStories from './drawer.nextjs.stories';
 
 # Drawer — Next.js (App Router)
 
-`Drawer` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box and can render inside a **Server Component**.
+> **TL;DR** — `Drawer` works in the Next.js App Router out of the box: import it and render it inside a **Server Component**. Use its named subpart exports (e.g. `DrawerPanel`) — not dot notation (`Drawer.X`). Put anything interactive (event handlers, state) in a file that starts with `'use client'`.
 
 ## Usage in a Server Component
 
@@ -24,8 +24,10 @@ export default function Demo() {
 		<Drawer open={ open } setOpen={ setOpen } position="right" trigger={ <Button>Open Drawer</Button> }>
 			<DrawerPanel>
 				<DrawerHeader>
-					<DrawerTitle>Drawer Title</DrawerTitle>
-					<DrawerCloseButton />
+					<div className="flex items-center justify-between">
+						<DrawerTitle>Drawer Title</DrawerTitle>
+						<DrawerCloseButton />
+					</div>
 				</DrawerHeader>
 				<DrawerBody>Drawer body content.</DrawerBody>
 				<DrawerFooter>
@@ -61,6 +63,6 @@ import { Drawer } from '@bsf/force-ui';
 
 ## Live preview
 
-_Rendered with the named (App-Router) pattern. Use **Show code** to copy it._
+_Rendered with the named (App-Router) pattern._
 
 <Canvas of={NextjsStories.ServerComponentPattern} />

--- a/src/components/drawer/drawer.nextjs.mdx
+++ b/src/components/drawer/drawer.nextjs.mdx
@@ -1,0 +1,66 @@
+import { Meta, Canvas } from '@storybook/addon-docs/blocks';
+import * as Stories from './drawer.stories';
+import * as NextjsStories from './drawer.nextjs.stories';
+
+<Meta of={Stories} name="Next.js Usage" />
+
+# Drawer — Next.js (App Router)
+
+`Drawer` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box and can render inside a **Server Component**.
+
+## Usage in a Server Component
+
+Use the **named subpart exports** — not dot access (`Drawer.X`). In a Server Component, React cannot read sub-components attached to a client reference, so dot access resolves to `undefined`. The named exports are individual client references:
+
+```tsx
+// app/drawer-demo.tsx
+'use client';
+import { useState } from 'react';
+import { Drawer, DrawerPanel, DrawerHeader, DrawerTitle, DrawerBody, DrawerFooter, DrawerCloseButton, DrawerBackdrop, Button } from '@bsf/force-ui';
+
+export default function Demo() {
+	const [ open, setOpen ] = useState( false );
+	return (
+		<Drawer open={ open } setOpen={ setOpen } position="right" trigger={ <Button>Open Drawer</Button> }>
+			<DrawerPanel>
+				<DrawerHeader>
+					<DrawerTitle>Drawer Title</DrawerTitle>
+					<DrawerCloseButton />
+				</DrawerHeader>
+				<DrawerBody>Drawer body content.</DrawerBody>
+				<DrawerFooter>
+					<Button onClick={ () => setOpen( false ) }>Close</Button>
+				</DrawerFooter>
+			</DrawerPanel>
+			<DrawerBackdrop />
+		</Drawer>
+	);
+}
+```
+
+## Dot notation (client components only)
+
+Inside your own client components the familiar compound dot syntax still works — it is only Server Components that require the named exports above:
+
+```tsx
+'use client';
+import { Drawer } from '@bsf/force-ui';
+
+<Drawer open={ open } setOpen={ setOpen }>
+	<Drawer.Panel>
+		<Drawer.Header><Drawer.Title>Title</Drawer.Title><Drawer.CloseButton /></Drawer.Header>
+		<Drawer.Body>Body</Drawer.Body>
+	</Drawer.Panel>
+	<Drawer.Backdrop />
+</Drawer>
+```
+
+## Notes
+
+- Open state (`open` / `setOpen`) and the `trigger` live in a client component.
+
+## Live preview
+
+_Rendered with the named (App-Router) pattern. Use **Show code** to copy it._
+
+<Canvas of={NextjsStories.ServerComponentPattern} />

--- a/src/components/drawer/drawer.nextjs.stories.tsx
+++ b/src/components/drawer/drawer.nextjs.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+import { Drawer, DrawerPanel, DrawerHeader, DrawerTitle, DrawerBody, DrawerFooter, DrawerCloseButton, DrawerBackdrop, Button } from '@/components';
+
+// Powers the "Next.js Usage" docs <Canvas>. Hidden from the sidebar
+// (`!dev`) and excluded from autodocs — it only demonstrates the named
+// (App-Router) import pattern in an isolated preview with copyable code.
+const meta: Meta = {
+	title: 'Organisms/Drawer/Next.js Example',
+	component: Drawer,
+	tags: [ '!dev', '!autodocs' ],
+	parameters: { layout: 'padded' },
+};
+
+export default meta;
+
+export const ServerComponentPattern: StoryObj = {
+	name: 'Named exports (App Router)',
+	render: () => {
+		// eslint-disable-next-line react-hooks/rules-of-hooks
+		const [ open, setOpen ] = useState( false );
+		return (
+			<Drawer open={ open } setOpen={ setOpen } position="right" trigger={ <Button>Open Drawer</Button> }>
+				<DrawerPanel>
+					<DrawerHeader>
+						<DrawerTitle>Drawer Title</DrawerTitle>
+						<DrawerCloseButton />
+					</DrawerHeader>
+					<DrawerBody>Drawer body content.</DrawerBody>
+					<DrawerFooter>
+						<Button onClick={ () => setOpen( false ) }>Close</Button>
+					</DrawerFooter>
+				</DrawerPanel>
+				<DrawerBackdrop />
+			</Drawer>
+		);
+	},
+};

--- a/src/components/drawer/drawer.nextjs.stories.tsx
+++ b/src/components/drawer/drawer.nextjs.stories.tsx
@@ -9,7 +9,7 @@ const meta: Meta = {
 	title: 'Organisms/Drawer/Next.js Example',
 	component: Drawer,
 	tags: [ '!dev', '!autodocs' ],
-	parameters: { layout: 'padded' },
+	parameters: { layout: 'fullscreen' },
 };
 
 export default meta;
@@ -20,19 +20,23 @@ export const ServerComponentPattern: StoryObj = {
 		// eslint-disable-next-line react-hooks/rules-of-hooks
 		const [ open, setOpen ] = useState( false );
 		return (
-			<Drawer open={ open } setOpen={ setOpen } position="right" trigger={ <Button>Open Drawer</Button> }>
-				<DrawerPanel>
-					<DrawerHeader>
-						<DrawerTitle>Drawer Title</DrawerTitle>
-						<DrawerCloseButton />
-					</DrawerHeader>
-					<DrawerBody>Drawer body content.</DrawerBody>
-					<DrawerFooter>
-						<Button onClick={ () => setOpen( false ) }>Close</Button>
-					</DrawerFooter>
-				</DrawerPanel>
-				<DrawerBackdrop />
-			</Drawer>
+			<div className="h-[460px] flex items-center justify-center">
+				<Drawer open={ open } setOpen={ setOpen } position="right" trigger={ <Button>Open Drawer</Button> }>
+					<DrawerPanel>
+						<DrawerHeader>
+							<div className="flex items-center justify-between">
+								<DrawerTitle>Drawer Title</DrawerTitle>
+								<DrawerCloseButton />
+							</div>
+						</DrawerHeader>
+						<DrawerBody>Drawer body content.</DrawerBody>
+						<DrawerFooter>
+							<Button onClick={ () => setOpen( false ) }>Close</Button>
+						</DrawerFooter>
+					</DrawerPanel>
+					<DrawerBackdrop />
+				</Drawer>
+			</div>
 		);
 	},
 };

--- a/src/components/drawer/drawer.tsx
+++ b/src/components/drawer/drawer.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React, {
 	cloneElement,
 	createContext,
@@ -220,3 +221,15 @@ Drawer.Backdrop = DrawerBackdrop;
 Drawer.Portal = DrawerPortal;
 
 export default Drawer;
+
+export {
+	DrawerPanel,
+	DrawerHeader,
+	DrawerTitle,
+	DrawerDescription,
+	DrawerBody,
+	DrawerCloseButton,
+	DrawerFooter,
+	DrawerBackdrop,
+	DrawerPortal,
+};

--- a/src/components/drawer/index.ts
+++ b/src/components/drawer/index.ts
@@ -1,1 +1,12 @@
 export { default } from './drawer';
+export {
+	DrawerPanel,
+	DrawerHeader,
+	DrawerTitle,
+	DrawerDescription,
+	DrawerBody,
+	DrawerCloseButton,
+	DrawerFooter,
+	DrawerBackdrop,
+	DrawerPortal,
+} from './drawer';

--- a/src/components/dropdown-menu/dropdown-menu.nextjs.mdx
+++ b/src/components/dropdown-menu/dropdown-menu.nextjs.mdx
@@ -1,0 +1,65 @@
+import { Meta, Canvas } from '@storybook/addon-docs/blocks';
+import * as Stories from './dropdown-menu.stories';
+import * as NextjsStories from './dropdown-menu.nextjs.stories';
+
+<Meta of={Stories} name="Next.js Usage" />
+
+# DropdownMenu — Next.js (App Router)
+
+`DropdownMenu` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box and can render inside a **Server Component**.
+
+## Usage in a Server Component
+
+Use the **named subpart exports** — not dot access (`DropdownMenu.X`). In a Server Component, React cannot read sub-components attached to a client reference, so dot access resolves to `undefined`. The named exports are individual client references:
+
+```tsx
+// app/page.tsx — Server Component
+import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContentWrapper, DropdownMenuContent, DropdownMenuList, DropdownMenuItem, DropdownMenuSeparator, Button } from '@bsf/force-ui';
+
+export default function Page() {
+	return (
+		<DropdownMenu>
+			<DropdownMenuTrigger>
+				<Button>Open menu</Button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContentWrapper>
+				<DropdownMenuContent className="w-60">
+					<DropdownMenuList>
+						<DropdownMenuItem>Item 1</DropdownMenuItem>
+						<DropdownMenuSeparator />
+						<DropdownMenuItem>Item 2</DropdownMenuItem>
+					</DropdownMenuList>
+				</DropdownMenuContent>
+			</DropdownMenuContentWrapper>
+		</DropdownMenu>
+	);
+}
+```
+
+## Dot notation (client components only)
+
+Inside your own client components the familiar compound dot syntax still works — it is only Server Components that require the named exports above:
+
+```tsx
+'use client';
+import { DropdownMenu } from '@bsf/force-ui';
+
+<DropdownMenu>
+	<DropdownMenu.Trigger><Button>Open</Button></DropdownMenu.Trigger>
+	<DropdownMenu.ContentWrapper>
+		<DropdownMenu.Content>
+			<DropdownMenu.List><DropdownMenu.Item>Item</DropdownMenu.Item></DropdownMenu.List>
+		</DropdownMenu.Content>
+	</DropdownMenu.ContentWrapper>
+</DropdownMenu>
+```
+
+## Notes
+
+- Wrap the content in `DropdownMenuContentWrapper`. Open/close state is managed internally (click the trigger).
+
+## Live preview
+
+_Rendered with the named (App-Router) pattern. Use **Show code** to copy it._
+
+<Canvas of={NextjsStories.ServerComponentPattern} />

--- a/src/components/dropdown-menu/dropdown-menu.nextjs.mdx
+++ b/src/components/dropdown-menu/dropdown-menu.nextjs.mdx
@@ -6,7 +6,7 @@ import * as NextjsStories from './dropdown-menu.nextjs.stories';
 
 # DropdownMenu — Next.js (App Router)
 
-`DropdownMenu` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box and can render inside a **Server Component**.
+> **TL;DR** — `DropdownMenu` works in the Next.js App Router out of the box: import it and render it inside a **Server Component**. Use its named subpart exports (e.g. `DropdownMenuTrigger`) — not dot notation (`DropdownMenu.X`). Put anything interactive (event handlers, state) in a file that starts with `'use client'`.
 
 ## Usage in a Server Component
 
@@ -58,8 +58,24 @@ import { DropdownMenu } from '@bsf/force-ui';
 
 - Wrap the content in `DropdownMenuContentWrapper`. Open/close state is managed internally (click the trigger).
 
+## Event handlers & state
+
+Server Components can't hold state or receive event handlers (`onClick`, `onChange`, …). Move the interactive part into its own client component:
+
+```tsx
+'use client';
+import { DropdownMenu } from '@bsf/force-ui';
+
+export default function Interactive() {
+	// useState, onClick, onChange … live in this client file
+	return <DropdownMenu />;
+}
+```
+
+Then import that into your Server Component — the page itself stays a Server Component.
+
 ## Live preview
 
-_Rendered with the named (App-Router) pattern. Use **Show code** to copy it._
+_Rendered with the named (App-Router) pattern._
 
 <Canvas of={NextjsStories.ServerComponentPattern} />

--- a/src/components/dropdown-menu/dropdown-menu.nextjs.stories.tsx
+++ b/src/components/dropdown-menu/dropdown-menu.nextjs.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContentWrapper, DropdownMenuContent, DropdownMenuList, DropdownMenuItem, DropdownMenuSeparator, Button } from '@/components';
+
+// Powers the "Next.js Usage" docs <Canvas>. Hidden from the sidebar
+// (`!dev`) and excluded from autodocs — it only demonstrates the named
+// (App-Router) import pattern in an isolated preview with copyable code.
+const meta: Meta = {
+	title: 'Molecules/DropdownMenu/Next.js Example',
+	component: DropdownMenu,
+	tags: [ '!dev', '!autodocs' ],
+	parameters: { layout: 'padded' },
+};
+
+export default meta;
+
+export const ServerComponentPattern: StoryObj = {
+	name: 'Named exports (App Router)',
+	render: () => {
+		return (
+			<DropdownMenu>
+				<DropdownMenuTrigger>
+					<Button>Open menu</Button>
+				</DropdownMenuTrigger>
+				<DropdownMenuContentWrapper>
+					<DropdownMenuContent className="w-60">
+						<DropdownMenuList>
+							<DropdownMenuItem>Item 1</DropdownMenuItem>
+							<DropdownMenuSeparator />
+							<DropdownMenuItem>Item 2</DropdownMenuItem>
+						</DropdownMenuList>
+					</DropdownMenuContent>
+				</DropdownMenuContentWrapper>
+			</DropdownMenu>
+		);
+	},
+};

--- a/src/components/dropdown-menu/dropdown-menu.nextjs.stories.tsx
+++ b/src/components/dropdown-menu/dropdown-menu.nextjs.stories.tsx
@@ -8,7 +8,7 @@ const meta: Meta = {
 	title: 'Molecules/DropdownMenu/Next.js Example',
 	component: DropdownMenu,
 	tags: [ '!dev', '!autodocs' ],
-	parameters: { layout: 'padded' },
+	parameters: { layout: 'centered' },
 };
 
 export default meta;
@@ -17,20 +17,22 @@ export const ServerComponentPattern: StoryObj = {
 	name: 'Named exports (App Router)',
 	render: () => {
 		return (
-			<DropdownMenu>
-				<DropdownMenuTrigger>
-					<Button>Open menu</Button>
-				</DropdownMenuTrigger>
-				<DropdownMenuContentWrapper>
-					<DropdownMenuContent className="w-60">
-						<DropdownMenuList>
-							<DropdownMenuItem>Item 1</DropdownMenuItem>
-							<DropdownMenuSeparator />
-							<DropdownMenuItem>Item 2</DropdownMenuItem>
-						</DropdownMenuList>
-					</DropdownMenuContent>
-				</DropdownMenuContentWrapper>
-			</DropdownMenu>
+			<div className="flex justify-center">
+				<DropdownMenu>
+					<DropdownMenuTrigger>
+						<Button>Open menu</Button>
+					</DropdownMenuTrigger>
+					<DropdownMenuContentWrapper>
+						<DropdownMenuContent className="w-60">
+							<DropdownMenuList>
+								<DropdownMenuItem>Item 1</DropdownMenuItem>
+								<DropdownMenuSeparator />
+								<DropdownMenuItem>Item 2</DropdownMenuItem>
+							</DropdownMenuList>
+						</DropdownMenuContent>
+					</DropdownMenuContentWrapper>
+				</DropdownMenu>
+			</div>
 		);
 	},
 };

--- a/src/components/dropdown-menu/dropdown-menu.tsx
+++ b/src/components/dropdown-menu/dropdown-menu.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React, {
 	useState,
 	createContext,

--- a/src/components/dropdown-menu/index.ts
+++ b/src/components/dropdown-menu/index.ts
@@ -1,1 +1,10 @@
 export { default } from './dropdown-menu';
+export {
+	DropdownMenuTrigger,
+	DropdownMenuContent,
+	DropdownMenuList,
+	DropdownMenuItem,
+	DropdownMenuSeparator,
+	DropdownMenuPortal,
+	DropdownMenuContentWrapper,
+} from './dropdown-menu';

--- a/src/components/dropzone/dropzone.nextjs.mdx
+++ b/src/components/dropzone/dropzone.nextjs.mdx
@@ -5,7 +5,7 @@ import * as Stories from './dropzone.stories';
 
 # Dropzone — Next.js (App Router)
 
-`Dropzone` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box. Import it and render it directly inside a **Server Component**.
+> **TL;DR** — `Dropzone` works in the Next.js App Router out of the box: import it and render it inside a **Server Component**. Put anything interactive (event handlers, state) in a file that starts with `'use client'`.
 
 ## Usage in a Server Component
 
@@ -21,6 +21,22 @@ export default function Page() {
 ## Notes
 
 - Value/`onChange` handlers must be defined in a client component.
+
+## Event handlers & state
+
+Server Components can't hold state or receive event handlers (`onClick`, `onChange`, …). Move the interactive part into its own client component:
+
+```tsx
+'use client';
+import { Dropzone } from '@bsf/force-ui';
+
+export default function Interactive() {
+	// useState, onClick, onChange … live in this client file
+	return <Dropzone />;
+}
+```
+
+Then import that into your Server Component — the page itself stays a Server Component.
 
 ## Live preview
 

--- a/src/components/dropzone/dropzone.nextjs.mdx
+++ b/src/components/dropzone/dropzone.nextjs.mdx
@@ -1,0 +1,27 @@
+import { Meta, Canvas } from '@storybook/addon-docs/blocks';
+import * as Stories from './dropzone.stories';
+
+<Meta of={Stories} name="Next.js Usage" />
+
+# Dropzone — Next.js (App Router)
+
+`Dropzone` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box. Import it and render it directly inside a **Server Component**.
+
+## Usage in a Server Component
+
+```tsx
+// app/page.tsx — Server Component
+import { Dropzone } from '@bsf/force-ui';
+
+export default function Page() {
+	return <Dropzone />;
+}
+```
+
+## Notes
+
+- Value/`onChange` handlers must be defined in a client component.
+
+## Live preview
+
+<Canvas of={Stories.Basic} />

--- a/src/components/dropzone/dropzone.tsx
+++ b/src/components/dropzone/dropzone.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { useState, createContext, useContext, useRef, useMemo } from 'react';
 import { CloudUpload, File, ImageOff, Trash } from 'lucide-react';
 import { cn, formatFileSize } from '@/utilities/functions';

--- a/src/components/editor-input/editor-input.nextjs.mdx
+++ b/src/components/editor-input/editor-input.nextjs.mdx
@@ -5,7 +5,7 @@ import * as Stories from './editor-input.stories';
 
 # EditorInput — Next.js (App Router)
 
-`EditorInput` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box. Import it and render it directly inside a **Server Component**.
+> **TL;DR** — `EditorInput` works in the Next.js App Router out of the box: import it and render it inside a **Server Component**. Put anything interactive (event handlers, state) in a file that starts with `'use client'`.
 
 ## Usage in a Server Component
 
@@ -21,6 +21,22 @@ export default function Page() {
 ## Notes
 
 - Value/`onChange` handlers must be defined in a client component.
+
+## Event handlers & state
+
+Server Components can't hold state or receive event handlers (`onClick`, `onChange`, …). Move the interactive part into its own client component:
+
+```tsx
+'use client';
+import { EditorInput } from '@bsf/force-ui';
+
+export default function Interactive() {
+	// useState, onClick, onChange … live in this client file
+	return <EditorInput />;
+}
+```
+
+Then import that into your Server Component — the page itself stays a Server Component.
 
 ## Live preview
 

--- a/src/components/editor-input/editor-input.nextjs.mdx
+++ b/src/components/editor-input/editor-input.nextjs.mdx
@@ -1,0 +1,27 @@
+import { Meta, Canvas } from '@storybook/addon-docs/blocks';
+import * as Stories from './editor-input.stories';
+
+<Meta of={Stories} name="Next.js Usage" />
+
+# EditorInput — Next.js (App Router)
+
+`EditorInput` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box. Import it and render it directly inside a **Server Component**.
+
+## Usage in a Server Component
+
+```tsx
+// app/page.tsx — Server Component
+import { EditorInput } from '@bsf/force-ui';
+
+export default function Page() {
+	return <EditorInput />;
+}
+```
+
+## Notes
+
+- Value/`onChange` handlers must be defined in a client component.
+
+## Live preview
+
+<Canvas of={Stories.Default} />

--- a/src/components/editor-input/editor-input.tsx
+++ b/src/components/editor-input/editor-input.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { AutoFocusPlugin } from '@lexical/react/LexicalAutoFocusPlugin';
 import { LexicalComposer } from '@lexical/react/LexicalComposer';
 import { PlainTextPlugin } from '@lexical/react/LexicalPlainTextPlugin';

--- a/src/components/file-preview/file-preview.nextjs.mdx
+++ b/src/components/file-preview/file-preview.nextjs.mdx
@@ -5,7 +5,7 @@ import * as Stories from './file-preview.stories';
 
 # FilePreview — Next.js (App Router)
 
-`FilePreview` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box. Import it and render it directly inside a **Server Component**.
+> **TL;DR** — `FilePreview` works in the Next.js App Router out of the box: import it and render it inside a **Server Component**. Put anything interactive (event handlers, state) in a file that starts with `'use client'`.
 
 ## Usage in a Server Component
 
@@ -17,6 +17,22 @@ export default function Page() {
 	return <FilePreview />;
 }
 ```
+
+## Event handlers & state
+
+Server Components can't hold state or receive event handlers (`onClick`, `onChange`, …). Move the interactive part into its own client component:
+
+```tsx
+'use client';
+import { FilePreview } from '@bsf/force-ui';
+
+export default function Interactive() {
+	// useState, onClick, onChange … live in this client file
+	return <FilePreview />;
+}
+```
+
+Then import that into your Server Component — the page itself stays a Server Component.
 
 ## Live preview
 

--- a/src/components/file-preview/file-preview.nextjs.mdx
+++ b/src/components/file-preview/file-preview.nextjs.mdx
@@ -1,0 +1,23 @@
+import { Meta, Canvas } from '@storybook/addon-docs/blocks';
+import * as Stories from './file-preview.stories';
+
+<Meta of={Stories} name="Next.js Usage" />
+
+# FilePreview — Next.js (App Router)
+
+`FilePreview` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box. Import it and render it directly inside a **Server Component**.
+
+## Usage in a Server Component
+
+```tsx
+// app/page.tsx — Server Component
+import { FilePreview } from '@bsf/force-ui';
+
+export default function Page() {
+	return <FilePreview />;
+}
+```
+
+## Live preview
+
+<Canvas of={Stories.Default} />

--- a/src/components/file-preview/file-preview.tsx
+++ b/src/components/file-preview/file-preview.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { cn, formatFileSize } from '@/utilities/functions';
 import { File, ImageOff, Trash } from 'lucide-react';
 

--- a/src/components/hamburger-menu/hamburger-menu.nextjs.mdx
+++ b/src/components/hamburger-menu/hamburger-menu.nextjs.mdx
@@ -1,0 +1,54 @@
+import { Meta, Canvas } from '@storybook/addon-docs/blocks';
+import * as Stories from './hamburger-menu.stories';
+import * as NextjsStories from './hamburger-menu.nextjs.stories';
+
+<Meta of={Stories} name="Next.js Usage" />
+
+# HamburgerMenu — Next.js (App Router)
+
+`HamburgerMenu` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box and can render inside a **Server Component**.
+
+## Usage in a Server Component
+
+Use the **named subpart exports** — not dot access (`HamburgerMenu.X`). In a Server Component, React cannot read sub-components attached to a client reference, so dot access resolves to `undefined`. The named exports are individual client references:
+
+```tsx
+// app/page.tsx — Server Component
+import { HamburgerMenu, HamburgerMenuToggle, HamburgerMenuOptions, HamburgerMenuOption } from '@bsf/force-ui';
+
+export default function Page() {
+	return (
+		<HamburgerMenu>
+			<HamburgerMenuToggle />
+			<HamburgerMenuOptions>
+				<HamburgerMenuOption>Option 1</HamburgerMenuOption>
+				<HamburgerMenuOption>Option 2</HamburgerMenuOption>
+			</HamburgerMenuOptions>
+		</HamburgerMenu>
+	);
+}
+```
+
+> `HamburgerMenu.Options/Option/Toggle` are exported as **`HamburgerMenuOptions`, `HamburgerMenuOption`, `HamburgerMenuToggle`**.
+
+## Dot notation (client components only)
+
+Inside your own client components the familiar compound dot syntax still works — it is only Server Components that require the named exports above:
+
+```tsx
+'use client';
+import { HamburgerMenu } from '@bsf/force-ui';
+
+<HamburgerMenu>
+	<HamburgerMenu.Toggle />
+	<HamburgerMenu.Options>
+		<HamburgerMenu.Option>Option</HamburgerMenu.Option>
+	</HamburgerMenu.Options>
+</HamburgerMenu>
+```
+
+## Live preview
+
+_Rendered with the named (App-Router) pattern. Use **Show code** to copy it._
+
+<Canvas of={NextjsStories.ServerComponentPattern} />

--- a/src/components/hamburger-menu/hamburger-menu.nextjs.mdx
+++ b/src/components/hamburger-menu/hamburger-menu.nextjs.mdx
@@ -6,7 +6,7 @@ import * as NextjsStories from './hamburger-menu.nextjs.stories';
 
 # HamburgerMenu — Next.js (App Router)
 
-`HamburgerMenu` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box and can render inside a **Server Component**.
+> **TL;DR** — `HamburgerMenu` works in the Next.js App Router out of the box: import it and render it inside a **Server Component**. Use its named subpart exports (e.g. `HamburgerMenuToggle`) — not dot notation (`HamburgerMenu.X`). Put anything interactive (event handlers, state) in a file that starts with `'use client'`.
 
 ## Usage in a Server Component
 
@@ -47,8 +47,24 @@ import { HamburgerMenu } from '@bsf/force-ui';
 </HamburgerMenu>
 ```
 
+## Event handlers & state
+
+Server Components can't hold state or receive event handlers (`onClick`, `onChange`, …). Move the interactive part into its own client component:
+
+```tsx
+'use client';
+import { HamburgerMenu } from '@bsf/force-ui';
+
+export default function Interactive() {
+	// useState, onClick, onChange … live in this client file
+	return <HamburgerMenu />;
+}
+```
+
+Then import that into your Server Component — the page itself stays a Server Component.
+
 ## Live preview
 
-_Rendered with the named (App-Router) pattern. Use **Show code** to copy it._
+_Rendered with the named (App-Router) pattern._
 
 <Canvas of={NextjsStories.ServerComponentPattern} />

--- a/src/components/hamburger-menu/hamburger-menu.nextjs.stories.tsx
+++ b/src/components/hamburger-menu/hamburger-menu.nextjs.stories.tsx
@@ -8,7 +8,7 @@ const meta: Meta = {
 	title: 'Organisms/Hamburger Menu/Next.js Example',
 	component: HamburgerMenu,
 	tags: [ '!dev', '!autodocs' ],
-	parameters: { layout: 'padded' },
+	parameters: { layout: 'fullscreen' },
 };
 
 export default meta;
@@ -17,13 +17,15 @@ export const ServerComponentPattern: StoryObj = {
 	name: 'Named exports (App Router)',
 	render: () => {
 		return (
-			<HamburgerMenu>
-				<HamburgerMenuToggle />
-				<HamburgerMenuOptions>
-					<HamburgerMenuOption>Option 1</HamburgerMenuOption>
-					<HamburgerMenuOption>Option 2</HamburgerMenuOption>
-				</HamburgerMenuOptions>
-			</HamburgerMenu>
+			<div className="h-[360px]">
+				<HamburgerMenu>
+					<HamburgerMenuToggle />
+					<HamburgerMenuOptions>
+						<HamburgerMenuOption>Option 1</HamburgerMenuOption>
+						<HamburgerMenuOption>Option 2</HamburgerMenuOption>
+					</HamburgerMenuOptions>
+				</HamburgerMenu>
+			</div>
 		);
 	},
 };

--- a/src/components/hamburger-menu/hamburger-menu.nextjs.stories.tsx
+++ b/src/components/hamburger-menu/hamburger-menu.nextjs.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { HamburgerMenu, HamburgerMenuToggle, HamburgerMenuOptions, HamburgerMenuOption } from '@/components';
+
+// Powers the "Next.js Usage" docs <Canvas>. Hidden from the sidebar
+// (`!dev`) and excluded from autodocs — it only demonstrates the named
+// (App-Router) import pattern in an isolated preview with copyable code.
+const meta: Meta = {
+	title: 'Organisms/Hamburger Menu/Next.js Example',
+	component: HamburgerMenu,
+	tags: [ '!dev', '!autodocs' ],
+	parameters: { layout: 'padded' },
+};
+
+export default meta;
+
+export const ServerComponentPattern: StoryObj = {
+	name: 'Named exports (App Router)',
+	render: () => {
+		return (
+			<HamburgerMenu>
+				<HamburgerMenuToggle />
+				<HamburgerMenuOptions>
+					<HamburgerMenuOption>Option 1</HamburgerMenuOption>
+					<HamburgerMenuOption>Option 2</HamburgerMenuOption>
+				</HamburgerMenuOptions>
+			</HamburgerMenu>
+		);
+	},
+};

--- a/src/components/hamburger-menu/hamburger-menu.tsx
+++ b/src/components/hamburger-menu/hamburger-menu.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { Button } from '@/components';
 import { cn } from '@/utilities/functions';
 import { motion, useCycle } from 'framer-motion';

--- a/src/components/hamburger-menu/index.ts
+++ b/src/components/hamburger-menu/index.ts
@@ -1,1 +1,6 @@
 export { default } from './hamburger-menu';
+export {
+	MenuOptions as HamburgerMenuOptions,
+	MenuOption as HamburgerMenuOption,
+	MenuToggle as HamburgerMenuToggle,
+} from './hamburger-menu';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,9 +1,8 @@
-'use client';
-
 export { default as Button } from './button';
 export { default as Switch } from './switch';
 export { default as Checkbox } from './checkbox';
 export { default as RadioButton } from './radio-button';
+export { RadioButtonGroup } from './radio-button';
 export { default as Badge } from './badge';
 export { default as TextArea } from './textarea';
 export { default as Avatar } from './avatar';
@@ -16,6 +15,14 @@ export { default as Tooltip } from './tooltip';
 export { default as ButtonGroup } from './button-group';
 export { default as Tabs } from './tabs';
 export { default as Select } from './select';
+export {
+	SelectButton,
+	SelectOptions,
+	SelectItem,
+	SelectItem as SelectOption,
+	SelectOptionGroup,
+	SelectPortal,
+} from './select';
 export * from './toaster';
 export { default as Container } from './container';
 export { default as Alert } from './alert';
@@ -24,6 +31,12 @@ export { default as ProgressSteps } from './progress-steps';
 export { default as Skeleton } from './skeleton';
 export { default as Menu } from './menu-item';
 export { default as Sidebar } from './sidebar';
+export {
+	SidebarHeader,
+	SidebarBody,
+	SidebarFooter,
+	SidebarItem,
+} from './sidebar';
 export { default as Breadcrumb } from './breadcrumb';
 export { default as Dialog } from './dialog';
 export { default as Topbar } from './topbar';
@@ -34,6 +47,11 @@ export { default as Drawer } from './drawer';
 export { default as Pagination } from './pagination';
 export { default as DatePicker } from './datepicker';
 export { default as Accordion } from './accordion';
+export {
+	AccordionItem,
+	AccordionTrigger,
+	AccordionContent,
+} from './accordion';
 export { default as BarChart } from './bar-chart';
 export { default as LineChart } from './line-chart';
 export { default as PieChart } from './pie-chart';
@@ -42,3 +60,97 @@ export { default as Dropzone } from './dropzone';
 export { default as Table } from './table';
 export { default as FilePreview } from './file-preview';
 export { default as Text } from './text';
+
+// --- RSC: named compound subparts (dot-matching) ---
+export {
+	DialogPanel,
+	DialogPortal,
+	DialogTitle,
+	DialogDescription,
+	DialogCloseButton,
+	DialogHeader,
+	DialogBody,
+	DialogFooter,
+	DialogBackdrop,
+} from './dialog';
+export {
+	DrawerPanel,
+	DrawerHeader,
+	DrawerTitle,
+	DrawerDescription,
+	DrawerBody,
+	DrawerCloseButton,
+	DrawerFooter,
+	DrawerBackdrop,
+	DrawerPortal,
+} from './drawer';
+export {
+	TableHead,
+	TableHeadCell,
+	TableBody,
+	TableRow,
+	TableCell,
+	TableFooter,
+} from './table';
+export {
+	DropdownMenuTrigger,
+	DropdownMenuContent,
+	DropdownMenuList,
+	DropdownMenuItem,
+	DropdownMenuSeparator,
+	DropdownMenuPortal,
+	DropdownMenuContentWrapper,
+} from './dropdown-menu';
+export {
+	SearchBoxInput,
+	SearchBoxLoading,
+	SearchBoxSeparator,
+	SearchBoxContent,
+	SearchBoxList,
+	SearchBoxEmpty,
+	SearchBoxGroup,
+	SearchBoxItem,
+	SearchBoxPortal,
+} from './search';
+export {
+	BreadcrumbList,
+	BreadcrumbItem,
+	BreadcrumbLink,
+	BreadcrumbSeparator,
+	BreadcrumbEllipsis,
+	BreadcrumbPage,
+} from './breadcrumb';
+export {
+	PaginationContent,
+	PaginationItem,
+	PaginationPrevious,
+	PaginationNext,
+	PaginationEllipsis,
+} from './pagination';
+export {
+	TabsGroup,
+	TabsTab,
+	TabsPanel,
+} from './tabs';
+export {
+	MenuList,
+	MenuItem,
+	MenuSeparator,
+} from './menu-item';
+export {
+	TopbarLeft,
+	TopbarMiddle,
+	TopbarRight,
+	TopbarItem,
+} from './topbar';
+export {
+	HamburgerMenuOptions,
+	HamburgerMenuOption,
+	HamburgerMenuToggle,
+} from './hamburger-menu';
+export {
+	ContainerItem,
+} from './container';
+export {
+	ProgressStep,
+} from './progress-steps';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -13,6 +13,7 @@ export { default as Loader } from './loader';
 export { default as ProgressBar } from './progress-bar';
 export { default as Tooltip } from './tooltip';
 export { default as ButtonGroup } from './button-group';
+export { ButtonGroupContainer, ButtonGroupButton } from './button-group';
 export { default as Tabs } from './tabs';
 export { default as Select } from './select';
 export {

--- a/src/components/input/input.nextjs.mdx
+++ b/src/components/input/input.nextjs.mdx
@@ -1,0 +1,27 @@
+import { Meta, Canvas } from '@storybook/addon-docs/blocks';
+import * as Stories from './input.stories';
+
+<Meta of={Stories} name="Next.js Usage" />
+
+# Input — Next.js (App Router)
+
+`Input` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box. Import it and render it directly inside a **Server Component**.
+
+## Usage in a Server Component
+
+```tsx
+// app/page.tsx — Server Component
+import { Input } from '@bsf/force-ui';
+
+export default function Page() {
+	return <Input />;
+}
+```
+
+## Notes
+
+- Value/`onChange` handlers must be defined in a client component.
+
+## Live preview
+
+<Canvas of={Stories.Basic} />

--- a/src/components/input/input.nextjs.mdx
+++ b/src/components/input/input.nextjs.mdx
@@ -5,7 +5,7 @@ import * as Stories from './input.stories';
 
 # Input — Next.js (App Router)
 
-`Input` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box. Import it and render it directly inside a **Server Component**.
+> **TL;DR** — `Input` works in the Next.js App Router out of the box: import it and render it inside a **Server Component**. Put anything interactive (event handlers, state) in a file that starts with `'use client'`.
 
 ## Usage in a Server Component
 
@@ -21,6 +21,22 @@ export default function Page() {
 ## Notes
 
 - Value/`onChange` handlers must be defined in a client component.
+
+## Event handlers & state
+
+Server Components can't hold state or receive event handlers (`onClick`, `onChange`, …). Move the interactive part into its own client component:
+
+```tsx
+'use client';
+import { Input } from '@bsf/force-ui';
+
+export default function Interactive() {
+	// useState, onClick, onChange … live in this client file
+	return <Input />;
+}
+```
+
+Then import that into your Server Component — the page itself stays a Server Component.
 
 ## Live preview
 

--- a/src/components/input/input.tsx
+++ b/src/components/input/input.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React, {
 	useState,
 	useCallback,

--- a/src/components/label/label.nextjs.mdx
+++ b/src/components/label/label.nextjs.mdx
@@ -5,7 +5,7 @@ import * as Stories from './label.stories';
 
 # Label — Next.js (App Router)
 
-`Label` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box. Import it and render it directly inside a **Server Component**.
+> **TL;DR** — `Label` works in the Next.js App Router out of the box: import it and render it inside a **Server Component**. Put anything interactive (event handlers, state) in a file that starts with `'use client'`.
 
 ## Usage in a Server Component
 
@@ -17,6 +17,22 @@ export default function Page() {
 	return <Label />;
 }
 ```
+
+## Event handlers & state
+
+Server Components can't hold state or receive event handlers (`onClick`, `onChange`, …). Move the interactive part into its own client component:
+
+```tsx
+'use client';
+import { Label } from '@bsf/force-ui';
+
+export default function Interactive() {
+	// useState, onClick, onChange … live in this client file
+	return <Label />;
+}
+```
+
+Then import that into your Server Component — the page itself stays a Server Component.
 
 ## Live preview
 

--- a/src/components/label/label.nextjs.mdx
+++ b/src/components/label/label.nextjs.mdx
@@ -1,0 +1,23 @@
+import { Meta, Canvas } from '@storybook/addon-docs/blocks';
+import * as Stories from './label.stories';
+
+<Meta of={Stories} name="Next.js Usage" />
+
+# Label — Next.js (App Router)
+
+`Label` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box. Import it and render it directly inside a **Server Component**.
+
+## Usage in a Server Component
+
+```tsx
+// app/page.tsx — Server Component
+import { Label } from '@bsf/force-ui';
+
+export default function Page() {
+	return <Label />;
+}
+```
+
+## Live preview
+
+<Canvas of={Stories.Basic} />

--- a/src/components/label/label.tsx
+++ b/src/components/label/label.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { cn } from '@/utilities/functions';
 import React, { type ElementType, forwardRef, type ReactNode } from 'react';
 

--- a/src/components/line-chart/line-chart.nextjs.mdx
+++ b/src/components/line-chart/line-chart.nextjs.mdx
@@ -1,0 +1,27 @@
+import { Meta, Canvas } from '@storybook/addon-docs/blocks';
+import * as Stories from './line-chart.stories';
+
+<Meta of={Stories} name="Next.js Usage" />
+
+# LineChart — Next.js (App Router)
+
+`LineChart` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box. Import it and render it directly inside a **Server Component**.
+
+## Usage in a Server Component
+
+```tsx
+// app/page.tsx — Server Component
+import { LineChart } from '@bsf/force-ui';
+
+export default function Page() {
+	return <LineChart />;
+}
+```
+
+## Notes
+
+- Chart data is passed as props; renders client-side after hydration.
+
+## Live preview
+
+<Canvas of={Stories.LineChartSimple} />

--- a/src/components/line-chart/line-chart.nextjs.mdx
+++ b/src/components/line-chart/line-chart.nextjs.mdx
@@ -5,7 +5,7 @@ import * as Stories from './line-chart.stories';
 
 # LineChart — Next.js (App Router)
 
-`LineChart` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box. Import it and render it directly inside a **Server Component**.
+> **TL;DR** — `LineChart` works in the Next.js App Router out of the box: import it and render it inside a **Server Component**. Put anything interactive (event handlers, state) in a file that starts with `'use client'`.
 
 ## Usage in a Server Component
 
@@ -21,6 +21,22 @@ export default function Page() {
 ## Notes
 
 - Chart data is passed as props; renders client-side after hydration.
+
+## Event handlers & state
+
+Server Components can't hold state or receive event handlers (`onClick`, `onChange`, …). Move the interactive part into its own client component:
+
+```tsx
+'use client';
+import { LineChart } from '@bsf/force-ui';
+
+export default function Interactive() {
+	// useState, onClick, onChange … live in this client file
+	return <LineChart />;
+}
+```
+
+Then import that into your Server Component — the page itself stays a Server Component.
 
 ## Live preview
 

--- a/src/components/line-chart/line-chart.tsx
+++ b/src/components/line-chart/line-chart.tsx
@@ -1,3 +1,4 @@
+'use client';
 import {
 	LineChart as LineChartWrapper,
 	Line,

--- a/src/components/loader/loader.nextjs.mdx
+++ b/src/components/loader/loader.nextjs.mdx
@@ -1,0 +1,23 @@
+import { Meta, Canvas } from '@storybook/addon-docs/blocks';
+import * as Stories from './loader.stories';
+
+<Meta of={Stories} name="Next.js Usage" />
+
+# Loader — Next.js (App Router)
+
+`Loader` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box. Import it and render it directly inside a **Server Component**.
+
+## Usage in a Server Component
+
+```tsx
+// app/page.tsx — Server Component
+import { Loader } from '@bsf/force-ui';
+
+export default function Page() {
+	return <Loader />;
+}
+```
+
+## Live preview
+
+<Canvas of={Stories.Basic} />

--- a/src/components/loader/loader.nextjs.mdx
+++ b/src/components/loader/loader.nextjs.mdx
@@ -5,7 +5,7 @@ import * as Stories from './loader.stories';
 
 # Loader — Next.js (App Router)
 
-`Loader` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box. Import it and render it directly inside a **Server Component**.
+> **TL;DR** — `Loader` works in the Next.js App Router out of the box: import it and render it inside a **Server Component**. Put anything interactive (event handlers, state) in a file that starts with `'use client'`.
 
 ## Usage in a Server Component
 
@@ -17,6 +17,22 @@ export default function Page() {
 	return <Loader />;
 }
 ```
+
+## Event handlers & state
+
+Server Components can't hold state or receive event handlers (`onClick`, `onChange`, …). Move the interactive part into its own client component:
+
+```tsx
+'use client';
+import { Loader } from '@bsf/force-ui';
+
+export default function Interactive() {
+	// useState, onClick, onChange … live in this client file
+	return <Loader />;
+}
+```
+
+Then import that into your Server Component — the page itself stays a Server Component.
 
 ## Live preview
 

--- a/src/components/loader/loader.tsx
+++ b/src/components/loader/loader.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { cn } from '@/utilities/functions';
 import { LoaderCircle } from 'lucide-react';
 import { type ReactNode } from 'react';

--- a/src/components/menu-item/index.ts
+++ b/src/components/menu-item/index.ts
@@ -1,1 +1,6 @@
 export { default } from './menu-item';
+export {
+	MenuList,
+	MenuItem,
+	MenuSeparator,
+} from './menu-item';

--- a/src/components/menu-item/menu-item.nextjs.mdx
+++ b/src/components/menu-item/menu-item.nextjs.mdx
@@ -6,7 +6,7 @@ import * as NextjsStories from './menu-item.nextjs.stories';
 
 # Menu — Next.js (App Router)
 
-`Menu` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box and can render inside a **Server Component**.
+> **TL;DR** — `Menu` works in the Next.js App Router out of the box: import it and render it inside a **Server Component**. Use its named subpart exports (e.g. `MenuList`) — not dot notation (`Menu.X`). Put anything interactive (event handlers, state) in a file that starts with `'use client'`.
 
 ## Usage in a Server Component
 
@@ -44,8 +44,24 @@ import { Menu } from '@bsf/force-ui';
 </Menu>
 ```
 
+## Event handlers & state
+
+Server Components can't hold state or receive event handlers (`onClick`, `onChange`, …). Move the interactive part into its own client component:
+
+```tsx
+'use client';
+import { Menu } from '@bsf/force-ui';
+
+export default function Interactive() {
+	// useState, onClick, onChange … live in this client file
+	return <Menu />;
+}
+```
+
+Then import that into your Server Component — the page itself stays a Server Component.
+
 ## Live preview
 
-_Rendered with the named (App-Router) pattern. Use **Show code** to copy it._
+_Rendered with the named (App-Router) pattern._
 
 <Canvas of={NextjsStories.ServerComponentPattern} />

--- a/src/components/menu-item/menu-item.nextjs.mdx
+++ b/src/components/menu-item/menu-item.nextjs.mdx
@@ -1,0 +1,51 @@
+import { Meta, Canvas } from '@storybook/addon-docs/blocks';
+import * as Stories from './menu.stories';
+import * as NextjsStories from './menu-item.nextjs.stories';
+
+<Meta of={Stories} name="Next.js Usage" />
+
+# Menu — Next.js (App Router)
+
+`Menu` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box and can render inside a **Server Component**.
+
+## Usage in a Server Component
+
+Use the **named subpart exports** — not dot access (`Menu.X`). In a Server Component, React cannot read sub-components attached to a client reference, so dot access resolves to `undefined`. The named exports are individual client references:
+
+```tsx
+// app/page.tsx — Server Component
+import { Menu, MenuList, MenuItem, MenuSeparator } from '@bsf/force-ui';
+
+export default function Page() {
+	return (
+		<Menu>
+			<MenuList heading="Group">
+				<MenuItem>Item</MenuItem>
+				<MenuSeparator />
+			</MenuList>
+		</Menu>
+	);
+}
+```
+
+## Dot notation (client components only)
+
+Inside your own client components the familiar compound dot syntax still works — it is only Server Components that require the named exports above:
+
+```tsx
+'use client';
+import { Menu } from '@bsf/force-ui';
+
+<Menu>
+	<Menu.List heading="Group">
+		<Menu.Item>Item</Menu.Item>
+		<Menu.Separator />
+	</Menu.List>
+</Menu>
+```
+
+## Live preview
+
+_Rendered with the named (App-Router) pattern. Use **Show code** to copy it._
+
+<Canvas of={NextjsStories.ServerComponentPattern} />

--- a/src/components/menu-item/menu-item.nextjs.stories.tsx
+++ b/src/components/menu-item/menu-item.nextjs.stories.tsx
@@ -8,7 +8,7 @@ const meta: Meta = {
 	title: 'Molecules/Menu/Next.js Example',
 	component: Menu,
 	tags: [ '!dev', '!autodocs' ],
-	parameters: { layout: 'padded' },
+	parameters: { layout: 'centered' },
 };
 
 export default meta;
@@ -17,12 +17,14 @@ export const ServerComponentPattern: StoryObj = {
 	name: 'Named exports (App Router)',
 	render: () => {
 		return (
-			<Menu>
-				<MenuList heading="Group">
-					<MenuItem>Item</MenuItem>
-					<MenuSeparator />
-				</MenuList>
-			</Menu>
+			<div className="w-60">
+				<Menu>
+					<MenuList heading="Group">
+						<MenuItem>Item</MenuItem>
+						<MenuSeparator />
+					</MenuList>
+				</Menu>
+			</div>
 		);
 	},
 };

--- a/src/components/menu-item/menu-item.nextjs.stories.tsx
+++ b/src/components/menu-item/menu-item.nextjs.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Menu, MenuList, MenuItem, MenuSeparator } from '@/components';
+
+// Powers the "Next.js Usage" docs <Canvas>. Hidden from the sidebar
+// (`!dev`) and excluded from autodocs — it only demonstrates the named
+// (App-Router) import pattern in an isolated preview with copyable code.
+const meta: Meta = {
+	title: 'Molecules/Menu/Next.js Example',
+	component: Menu,
+	tags: [ '!dev', '!autodocs' ],
+	parameters: { layout: 'padded' },
+};
+
+export default meta;
+
+export const ServerComponentPattern: StoryObj = {
+	name: 'Named exports (App Router)',
+	render: () => {
+		return (
+			<Menu>
+				<MenuList heading="Group">
+					<MenuItem>Item</MenuItem>
+					<MenuSeparator />
+				</MenuList>
+			</Menu>
+		);
+	},
+};

--- a/src/components/menu-item/menu-item.tsx
+++ b/src/components/menu-item/menu-item.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { useState, createContext, useContext, type ReactNode } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { ChevronDown } from 'lucide-react';

--- a/src/components/pagination/index.ts
+++ b/src/components/pagination/index.ts
@@ -1,1 +1,8 @@
 export { default } from './pagination';
+export {
+	PaginationContent,
+	PaginationItem,
+	PaginationPrevious,
+	PaginationNext,
+	PaginationEllipsis,
+} from './pagination';

--- a/src/components/pagination/pagination.nextjs.mdx
+++ b/src/components/pagination/pagination.nextjs.mdx
@@ -1,0 +1,54 @@
+import { Meta, Canvas } from '@storybook/addon-docs/blocks';
+import * as Stories from './pagination.stories';
+import * as NextjsStories from './pagination.nextjs.stories';
+
+<Meta of={Stories} name="Next.js Usage" />
+
+# Pagination — Next.js (App Router)
+
+`Pagination` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box and can render inside a **Server Component**.
+
+## Usage in a Server Component
+
+Use the **named subpart exports** — not dot access (`Pagination.X`). In a Server Component, React cannot read sub-components attached to a client reference, so dot access resolves to `undefined`. The named exports are individual client references:
+
+```tsx
+// app/page.tsx — Server Component
+import { Pagination, PaginationContent, PaginationItem, PaginationPrevious, PaginationNext, PaginationEllipsis } from '@bsf/force-ui';
+
+export default function Page() {
+	return (
+		<Pagination>
+			<PaginationContent>
+				<PaginationPrevious />
+				<PaginationItem>1</PaginationItem>
+				<PaginationEllipsis />
+				<PaginationNext />
+			</PaginationContent>
+		</Pagination>
+	);
+}
+```
+
+## Dot notation (client components only)
+
+Inside your own client components the familiar compound dot syntax still works — it is only Server Components that require the named exports above:
+
+```tsx
+'use client';
+import { Pagination } from '@bsf/force-ui';
+
+<Pagination>
+	<Pagination.Content>
+		<Pagination.Previous />
+		<Pagination.Item>1</Pagination.Item>
+		<Pagination.Next />
+	</Pagination.Content>
+</Pagination>
+```
+
+## Live preview
+
+_Rendered with the named (App-Router) pattern. Use **Show code** to copy it._
+
+<Canvas of={NextjsStories.ServerComponentPattern} />

--- a/src/components/pagination/pagination.nextjs.mdx
+++ b/src/components/pagination/pagination.nextjs.mdx
@@ -6,7 +6,7 @@ import * as NextjsStories from './pagination.nextjs.stories';
 
 # Pagination — Next.js (App Router)
 
-`Pagination` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box and can render inside a **Server Component**.
+> **TL;DR** — `Pagination` works in the Next.js App Router out of the box: import it and render it inside a **Server Component**. Use its named subpart exports (e.g. `PaginationContent`) — not dot notation (`Pagination.X`). Put anything interactive (event handlers, state) in a file that starts with `'use client'`.
 
 ## Usage in a Server Component
 
@@ -47,8 +47,24 @@ import { Pagination } from '@bsf/force-ui';
 </Pagination>
 ```
 
+## Event handlers & state
+
+Server Components can't hold state or receive event handlers (`onClick`, `onChange`, …). Move the interactive part into its own client component:
+
+```tsx
+'use client';
+import { Pagination } from '@bsf/force-ui';
+
+export default function Interactive() {
+	// useState, onClick, onChange … live in this client file
+	return <Pagination />;
+}
+```
+
+Then import that into your Server Component — the page itself stays a Server Component.
+
 ## Live preview
 
-_Rendered with the named (App-Router) pattern. Use **Show code** to copy it._
+_Rendered with the named (App-Router) pattern._
 
 <Canvas of={NextjsStories.ServerComponentPattern} />

--- a/src/components/pagination/pagination.nextjs.stories.tsx
+++ b/src/components/pagination/pagination.nextjs.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Pagination, PaginationContent, PaginationItem, PaginationPrevious, PaginationNext, PaginationEllipsis } from '@/components';
+
+// Powers the "Next.js Usage" docs <Canvas>. Hidden from the sidebar
+// (`!dev`) and excluded from autodocs — it only demonstrates the named
+// (App-Router) import pattern in an isolated preview with copyable code.
+const meta: Meta = {
+	title: 'Molecules/Pagination/Next.js Example',
+	component: Pagination,
+	tags: [ '!dev', '!autodocs' ],
+	parameters: { layout: 'padded' },
+};
+
+export default meta;
+
+export const ServerComponentPattern: StoryObj = {
+	name: 'Named exports (App Router)',
+	render: () => {
+		return (
+			<Pagination>
+				<PaginationContent>
+					<PaginationPrevious />
+					<PaginationItem>1</PaginationItem>
+					<PaginationEllipsis />
+					<PaginationNext />
+				</PaginationContent>
+			</Pagination>
+		);
+	},
+};

--- a/src/components/pagination/pagination.nextjs.stories.tsx
+++ b/src/components/pagination/pagination.nextjs.stories.tsx
@@ -8,7 +8,7 @@ const meta: Meta = {
 	title: 'Molecules/Pagination/Next.js Example',
 	component: Pagination,
 	tags: [ '!dev', '!autodocs' ],
-	parameters: { layout: 'padded' },
+	parameters: { layout: 'centered' },
 };
 
 export default meta;

--- a/src/components/pagination/pagination.tsx
+++ b/src/components/pagination/pagination.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React, {
 	createContext,
 	useContext,

--- a/src/components/pie-chart/pie-chart.nextjs.mdx
+++ b/src/components/pie-chart/pie-chart.nextjs.mdx
@@ -5,7 +5,7 @@ import * as Stories from './pie-chart.stories';
 
 # PieChart — Next.js (App Router)
 
-`PieChart` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box. Import it and render it directly inside a **Server Component**.
+> **TL;DR** — `PieChart` works in the Next.js App Router out of the box: import it and render it inside a **Server Component**. Put anything interactive (event handlers, state) in a file that starts with `'use client'`.
 
 ## Usage in a Server Component
 
@@ -21,6 +21,22 @@ export default function Page() {
 ## Notes
 
 - Chart data is passed as props; renders client-side after hydration.
+
+## Event handlers & state
+
+Server Components can't hold state or receive event handlers (`onClick`, `onChange`, …). Move the interactive part into its own client component:
+
+```tsx
+'use client';
+import { PieChart } from '@bsf/force-ui';
+
+export default function Interactive() {
+	// useState, onClick, onChange … live in this client file
+	return <PieChart />;
+}
+```
+
+Then import that into your Server Component — the page itself stays a Server Component.
 
 ## Live preview
 

--- a/src/components/pie-chart/pie-chart.nextjs.mdx
+++ b/src/components/pie-chart/pie-chart.nextjs.mdx
@@ -1,0 +1,27 @@
+import { Meta, Canvas } from '@storybook/addon-docs/blocks';
+import * as Stories from './pie-chart.stories';
+
+<Meta of={Stories} name="Next.js Usage" />
+
+# PieChart — Next.js (App Router)
+
+`PieChart` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box. Import it and render it directly inside a **Server Component**.
+
+## Usage in a Server Component
+
+```tsx
+// app/page.tsx — Server Component
+import { PieChart } from '@bsf/force-ui';
+
+export default function Page() {
+	return <PieChart />;
+}
+```
+
+## Notes
+
+- Chart data is passed as props; renders client-side after hydration.
+
+## Live preview
+
+<Canvas of={Stories.PieChartSimple} />

--- a/src/components/pie-chart/pie-chart.tsx
+++ b/src/components/pie-chart/pie-chart.tsx
@@ -1,3 +1,4 @@
+'use client';
 import {
 	PieChart as PieChartWrapper,
 	Pie,

--- a/src/components/progress-bar/progress-bar.nextjs.mdx
+++ b/src/components/progress-bar/progress-bar.nextjs.mdx
@@ -1,0 +1,23 @@
+import { Meta, Canvas } from '@storybook/addon-docs/blocks';
+import * as Stories from './progress-bar.stories';
+
+<Meta of={Stories} name="Next.js Usage" />
+
+# ProgressBar — Next.js (App Router)
+
+`ProgressBar` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box. Import it and render it directly inside a **Server Component**.
+
+## Usage in a Server Component
+
+```tsx
+// app/page.tsx — Server Component
+import { ProgressBar } from '@bsf/force-ui';
+
+export default function Page() {
+	return <ProgressBar />;
+}
+```
+
+## Live preview
+
+<Canvas of={Stories.Basic} />

--- a/src/components/progress-bar/progress-bar.nextjs.mdx
+++ b/src/components/progress-bar/progress-bar.nextjs.mdx
@@ -5,7 +5,7 @@ import * as Stories from './progress-bar.stories';
 
 # ProgressBar — Next.js (App Router)
 
-`ProgressBar` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box. Import it and render it directly inside a **Server Component**.
+> **TL;DR** — `ProgressBar` works in the Next.js App Router out of the box: import it and render it inside a **Server Component**. Put anything interactive (event handlers, state) in a file that starts with `'use client'`.
 
 ## Usage in a Server Component
 
@@ -17,6 +17,22 @@ export default function Page() {
 	return <ProgressBar />;
 }
 ```
+
+## Event handlers & state
+
+Server Components can't hold state or receive event handlers (`onClick`, `onChange`, …). Move the interactive part into its own client component:
+
+```tsx
+'use client';
+import { ProgressBar } from '@bsf/force-ui';
+
+export default function Interactive() {
+	// useState, onClick, onChange … live in this client file
+	return <ProgressBar />;
+}
+```
+
+Then import that into your Server Component — the page itself stays a Server Component.
 
 ## Live preview
 

--- a/src/components/progress-bar/progress-bar.tsx
+++ b/src/components/progress-bar/progress-bar.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { cn } from '@/utilities/functions';
 
 export interface ProgressBarProps {

--- a/src/components/progress-steps/index.ts
+++ b/src/components/progress-steps/index.ts
@@ -1,1 +1,4 @@
 export { default } from './progress-steps';
+export {
+	ProgressStep,
+} from './progress-steps';

--- a/src/components/progress-steps/progress-steps.nextjs.mdx
+++ b/src/components/progress-steps/progress-steps.nextjs.mdx
@@ -1,0 +1,46 @@
+import { Meta, Canvas } from '@storybook/addon-docs/blocks';
+import * as Stories from './progress-steps.stories';
+import * as NextjsStories from './progress-steps.nextjs.stories';
+
+<Meta of={Stories} name="Next.js Usage" />
+
+# ProgressSteps — Next.js (App Router)
+
+`ProgressSteps` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box and can render inside a **Server Component**.
+
+## Usage in a Server Component
+
+Use the **named subpart exports** — not dot access (`ProgressSteps.X`). In a Server Component, React cannot read sub-components attached to a client reference, so dot access resolves to `undefined`. The named exports are individual client references:
+
+```tsx
+// app/page.tsx — Server Component
+import { ProgressSteps, ProgressStep } from '@bsf/force-ui';
+
+export default function Page() {
+	return (
+		<ProgressSteps>
+			<ProgressStep size="md">Step 1</ProgressStep>
+			<ProgressStep size="md">Step 2</ProgressStep>
+		</ProgressSteps>
+	);
+}
+```
+
+## Dot notation (client components only)
+
+Inside your own client components the familiar compound dot syntax still works — it is only Server Components that require the named exports above:
+
+```tsx
+'use client';
+import { ProgressSteps } from '@bsf/force-ui';
+
+<ProgressSteps>
+	<ProgressSteps.Step size="md">Step 1</ProgressSteps.Step>
+</ProgressSteps>
+```
+
+## Live preview
+
+_Rendered with the named (App-Router) pattern. Use **Show code** to copy it._
+
+<Canvas of={NextjsStories.ServerComponentPattern} />

--- a/src/components/progress-steps/progress-steps.nextjs.mdx
+++ b/src/components/progress-steps/progress-steps.nextjs.mdx
@@ -6,7 +6,7 @@ import * as NextjsStories from './progress-steps.nextjs.stories';
 
 # ProgressSteps — Next.js (App Router)
 
-`ProgressSteps` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box and can render inside a **Server Component**.
+> **TL;DR** — `ProgressSteps` works in the Next.js App Router out of the box: import it and render it inside a **Server Component**. Use its named subpart exports (e.g. `ProgressStep`) — not dot notation (`ProgressSteps.X`). Put anything interactive (event handlers, state) in a file that starts with `'use client'`.
 
 ## Usage in a Server Component
 
@@ -39,8 +39,24 @@ import { ProgressSteps } from '@bsf/force-ui';
 </ProgressSteps>
 ```
 
+## Event handlers & state
+
+Server Components can't hold state or receive event handlers (`onClick`, `onChange`, …). Move the interactive part into its own client component:
+
+```tsx
+'use client';
+import { ProgressSteps } from '@bsf/force-ui';
+
+export default function Interactive() {
+	// useState, onClick, onChange … live in this client file
+	return <ProgressSteps />;
+}
+```
+
+Then import that into your Server Component — the page itself stays a Server Component.
+
 ## Live preview
 
-_Rendered with the named (App-Router) pattern. Use **Show code** to copy it._
+_Rendered with the named (App-Router) pattern._
 
 <Canvas of={NextjsStories.ServerComponentPattern} />

--- a/src/components/progress-steps/progress-steps.nextjs.stories.tsx
+++ b/src/components/progress-steps/progress-steps.nextjs.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { ProgressSteps, ProgressStep } from '@/components';
+
+// Powers the "Next.js Usage" docs <Canvas>. Hidden from the sidebar
+// (`!dev`) and excluded from autodocs — it only demonstrates the named
+// (App-Router) import pattern in an isolated preview with copyable code.
+const meta: Meta = {
+	title: 'Atoms/ProgressSteps/Next.js Example',
+	component: ProgressSteps,
+	tags: [ '!dev', '!autodocs' ],
+	parameters: { layout: 'padded' },
+};
+
+export default meta;
+
+export const ServerComponentPattern: StoryObj = {
+	name: 'Named exports (App Router)',
+	render: () => {
+		return (
+			<ProgressSteps>
+				<ProgressStep size="md">Step 1</ProgressStep>
+				<ProgressStep size="md">Step 2</ProgressStep>
+			</ProgressSteps>
+		);
+	},
+};

--- a/src/components/progress-steps/progress-steps.nextjs.stories.tsx
+++ b/src/components/progress-steps/progress-steps.nextjs.stories.tsx
@@ -8,7 +8,7 @@ const meta: Meta = {
 	title: 'Atoms/ProgressSteps/Next.js Example',
 	component: ProgressSteps,
 	tags: [ '!dev', '!autodocs' ],
-	parameters: { layout: 'padded' },
+	parameters: { layout: 'centered' },
 };
 
 export default meta;
@@ -17,10 +17,12 @@ export const ServerComponentPattern: StoryObj = {
 	name: 'Named exports (App Router)',
 	render: () => {
 		return (
-			<ProgressSteps>
-				<ProgressStep size="md">Step 1</ProgressStep>
-				<ProgressStep size="md">Step 2</ProgressStep>
-			</ProgressSteps>
+			<div className="w-full max-w-xl">
+				<ProgressSteps>
+					<ProgressStep size="md">Step 1</ProgressStep>
+					<ProgressStep size="md">Step 2</ProgressStep>
+				</ProgressSteps>
+			</div>
 		);
 	},
 };

--- a/src/components/progress-steps/progress-steps.tsx
+++ b/src/components/progress-steps/progress-steps.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React, { type ReactNode } from 'react';
 import { cn } from '@/utilities/functions';
 import { Plus, Check } from 'lucide-react';

--- a/src/components/radio-button/index.ts
+++ b/src/components/radio-button/index.ts
@@ -1,1 +1,2 @@
 export { default } from './radio-button';
+export { RadioButtonGroup } from './radio-button';

--- a/src/components/radio-button/radio-button.nextjs.mdx
+++ b/src/components/radio-button/radio-button.nextjs.mdx
@@ -1,0 +1,46 @@
+import { Meta, Canvas } from '@storybook/addon-docs/blocks';
+import * as Stories from './radio-button.stories';
+import * as NextjsStories from './radio-button.nextjs.stories';
+
+<Meta of={Stories} name="Next.js Usage" />
+
+# RadioButton — Next.js (App Router)
+
+`RadioButton` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box and can render inside a **Server Component**.
+
+## Usage in a Server Component
+
+Use the **named subpart exports** — not dot access (`RadioButton.X`). In a Server Component, React cannot read sub-components attached to a client reference, so dot access resolves to `undefined`. The named exports are individual client references:
+
+```tsx
+// app/page.tsx — Server Component
+import { RadioButton, RadioButtonGroup } from '@bsf/force-ui';
+
+export default function Page() {
+	return (
+		<RadioButtonGroup defaultValue="a" columns={ 2 }>
+			<RadioButton value="a" label={ { heading: 'Option A' } } />
+			<RadioButton value="b" label={ { heading: 'Option B' } } />
+		</RadioButtonGroup>
+	);
+}
+```
+
+## Dot notation (client components only)
+
+Inside your own client components the familiar compound dot syntax still works — it is only Server Components that require the named exports above:
+
+```tsx
+'use client';
+import { RadioButton } from '@bsf/force-ui';
+
+<RadioButton.Group defaultValue="a">
+	<RadioButton value="a" label={ { heading: 'Option A' } } />
+</RadioButton.Group>
+```
+
+## Live preview
+
+_Rendered with the named (App-Router) pattern. Use **Show code** to copy it._
+
+<Canvas of={NextjsStories.ServerComponentPattern} />

--- a/src/components/radio-button/radio-button.nextjs.mdx
+++ b/src/components/radio-button/radio-button.nextjs.mdx
@@ -6,7 +6,7 @@ import * as NextjsStories from './radio-button.nextjs.stories';
 
 # RadioButton — Next.js (App Router)
 
-`RadioButton` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box and can render inside a **Server Component**.
+> **TL;DR** — `RadioButton` works in the Next.js App Router out of the box: import it and render it inside a **Server Component**. Use its named subpart exports (e.g. `RadioButtonGroup`) — not dot notation (`RadioButton.X`). Put anything interactive (event handlers, state) in a file that starts with `'use client'`.
 
 ## Usage in a Server Component
 
@@ -39,8 +39,24 @@ import { RadioButton } from '@bsf/force-ui';
 </RadioButton.Group>
 ```
 
+## Event handlers & state
+
+Server Components can't hold state or receive event handlers (`onClick`, `onChange`, …). Move the interactive part into its own client component:
+
+```tsx
+'use client';
+import { RadioButton } from '@bsf/force-ui';
+
+export default function Interactive() {
+	// useState, onClick, onChange … live in this client file
+	return <RadioButton />;
+}
+```
+
+Then import that into your Server Component — the page itself stays a Server Component.
+
 ## Live preview
 
-_Rendered with the named (App-Router) pattern. Use **Show code** to copy it._
+_Rendered with the named (App-Router) pattern._
 
 <Canvas of={NextjsStories.ServerComponentPattern} />

--- a/src/components/radio-button/radio-button.nextjs.stories.tsx
+++ b/src/components/radio-button/radio-button.nextjs.stories.tsx
@@ -8,7 +8,7 @@ const meta: Meta = {
 	title: 'Atoms/RadioButton/Next.js Example',
 	component: RadioButton,
 	tags: [ '!dev', '!autodocs' ],
-	parameters: { layout: 'padded' },
+	parameters: { layout: 'centered' },
 };
 
 export default meta;

--- a/src/components/radio-button/radio-button.nextjs.stories.tsx
+++ b/src/components/radio-button/radio-button.nextjs.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { RadioButton, RadioButtonGroup } from '@/components';
+
+// Powers the "Next.js Usage" docs <Canvas>. Hidden from the sidebar
+// (`!dev`) and excluded from autodocs — it only demonstrates the named
+// (App-Router) import pattern in an isolated preview with copyable code.
+const meta: Meta = {
+	title: 'Atoms/RadioButton/Next.js Example',
+	component: RadioButton,
+	tags: [ '!dev', '!autodocs' ],
+	parameters: { layout: 'padded' },
+};
+
+export default meta;
+
+export const ServerComponentPattern: StoryObj = {
+	name: 'Named exports (App Router)',
+	render: () => {
+		return (
+			<RadioButtonGroup defaultValue="a" columns={ 2 }>
+				<RadioButton value="a" label={ { heading: 'Option A' } } />
+				<RadioButton value="b" label={ { heading: 'Option B' } } />
+			</RadioButtonGroup>
+		);
+	},
+};

--- a/src/components/radio-button/radio-button.tsx
+++ b/src/components/radio-button/radio-button.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React, {
 	useState,
 	useCallback,

--- a/src/components/search/index.ts
+++ b/src/components/search/index.ts
@@ -1,1 +1,12 @@
 export { default } from './search';
+export {
+	SearchBoxInput,
+	SearchBoxLoading,
+	SearchBoxSeparator,
+	SearchBoxContent,
+	SearchBoxList,
+	SearchBoxEmpty,
+	SearchBoxGroup,
+	SearchBoxItem,
+	SearchBoxPortal,
+} from './search';

--- a/src/components/search/search.nextjs.mdx
+++ b/src/components/search/search.nextjs.mdx
@@ -1,0 +1,57 @@
+import { Meta, Canvas } from '@storybook/addon-docs/blocks';
+import * as Stories from './search.stories';
+import * as NextjsStories from './search.nextjs.stories';
+
+<Meta of={Stories} name="Next.js Usage" />
+
+# SearchBox — Next.js (App Router)
+
+`SearchBox` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box and can render inside a **Server Component**.
+
+## Usage in a Server Component
+
+Use the **named subpart exports** — not dot access (`SearchBox.X`). In a Server Component, React cannot read sub-components attached to a client reference, so dot access resolves to `undefined`. The named exports are individual client references:
+
+```tsx
+// app/page.tsx — Server Component
+import { SearchBox, SearchBoxInput, SearchBoxContent, SearchBoxList, SearchBoxItem } from '@bsf/force-ui';
+
+export default function Page() {
+	return (
+		<SearchBox>
+			<SearchBoxInput />
+			<SearchBoxContent>
+				<SearchBoxList>
+					<SearchBoxItem>Item</SearchBoxItem>
+				</SearchBoxList>
+			</SearchBoxContent>
+		</SearchBox>
+	);
+}
+```
+
+## Dot notation (client components only)
+
+Inside your own client components the familiar compound dot syntax still works — it is only Server Components that require the named exports above:
+
+```tsx
+'use client';
+import { SearchBox } from '@bsf/force-ui';
+
+<SearchBox>
+	<SearchBox.Input />
+	<SearchBox.Content>
+		<SearchBox.List><SearchBox.Item>Item</SearchBox.Item></SearchBox.List>
+	</SearchBox.Content>
+</SearchBox>
+```
+
+## Notes
+
+- Search value/handlers live in a client component.
+
+## Live preview
+
+_Rendered with the named (App-Router) pattern. Use **Show code** to copy it._
+
+<Canvas of={NextjsStories.ServerComponentPattern} />

--- a/src/components/search/search.nextjs.mdx
+++ b/src/components/search/search.nextjs.mdx
@@ -6,7 +6,7 @@ import * as NextjsStories from './search.nextjs.stories';
 
 # SearchBox — Next.js (App Router)
 
-`SearchBox` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box and can render inside a **Server Component**.
+> **TL;DR** — `SearchBox` works in the Next.js App Router out of the box: import it and render it inside a **Server Component**. Use its named subpart exports (e.g. `SearchBoxInput`) — not dot notation (`SearchBox.X`). Put anything interactive (event handlers, state) in a file that starts with `'use client'`.
 
 ## Usage in a Server Component
 
@@ -50,8 +50,24 @@ import { SearchBox } from '@bsf/force-ui';
 
 - Search value/handlers live in a client component.
 
+## Event handlers & state
+
+Server Components can't hold state or receive event handlers (`onClick`, `onChange`, …). Move the interactive part into its own client component:
+
+```tsx
+'use client';
+import { SearchBox } from '@bsf/force-ui';
+
+export default function Interactive() {
+	// useState, onClick, onChange … live in this client file
+	return <SearchBox />;
+}
+```
+
+Then import that into your Server Component — the page itself stays a Server Component.
+
 ## Live preview
 
-_Rendered with the named (App-Router) pattern. Use **Show code** to copy it._
+_Rendered with the named (App-Router) pattern._
 
 <Canvas of={NextjsStories.ServerComponentPattern} />

--- a/src/components/search/search.nextjs.stories.tsx
+++ b/src/components/search/search.nextjs.stories.tsx
@@ -8,7 +8,7 @@ const meta: Meta = {
 	title: 'Molecules/SearchBox/Next.js Example',
 	component: SearchBox,
 	tags: [ '!dev', '!autodocs' ],
-	parameters: { layout: 'padded' },
+	parameters: { layout: 'centered' },
 };
 
 export default meta;
@@ -17,14 +17,16 @@ export const ServerComponentPattern: StoryObj = {
 	name: 'Named exports (App Router)',
 	render: () => {
 		return (
-			<SearchBox>
-				<SearchBoxInput />
-				<SearchBoxContent>
-					<SearchBoxList>
-						<SearchBoxItem>Item</SearchBoxItem>
-					</SearchBoxList>
-				</SearchBoxContent>
-			</SearchBox>
+			<div className="w-full max-w-md">
+				<SearchBox>
+					<SearchBoxInput />
+					<SearchBoxContent>
+						<SearchBoxList>
+							<SearchBoxItem>Item</SearchBoxItem>
+						</SearchBoxList>
+					</SearchBoxContent>
+				</SearchBox>
+			</div>
 		);
 	},
 };

--- a/src/components/search/search.nextjs.stories.tsx
+++ b/src/components/search/search.nextjs.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { SearchBox, SearchBoxInput, SearchBoxContent, SearchBoxList, SearchBoxItem } from '@/components';
+
+// Powers the "Next.js Usage" docs <Canvas>. Hidden from the sidebar
+// (`!dev`) and excluded from autodocs — it only demonstrates the named
+// (App-Router) import pattern in an isolated preview with copyable code.
+const meta: Meta = {
+	title: 'Molecules/SearchBox/Next.js Example',
+	component: SearchBox,
+	tags: [ '!dev', '!autodocs' ],
+	parameters: { layout: 'padded' },
+};
+
+export default meta;
+
+export const ServerComponentPattern: StoryObj = {
+	name: 'Named exports (App Router)',
+	render: () => {
+		return (
+			<SearchBox>
+				<SearchBoxInput />
+				<SearchBoxContent>
+					<SearchBoxList>
+						<SearchBoxItem>Item</SearchBoxItem>
+					</SearchBoxList>
+				</SearchBoxContent>
+			</SearchBox>
+		);
+	},
+};

--- a/src/components/search/search.tsx
+++ b/src/components/search/search.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React, {
 	useState,
 	type ReactNode,

--- a/src/components/select/index.ts
+++ b/src/components/select/index.ts
@@ -1,1 +1,9 @@
 export { default } from './select';
+export {
+	SelectButton,
+	SelectOptions,
+	SelectItem,
+	SelectItem as SelectOption,
+	SelectOptionGroup,
+	SelectPortal,
+} from './select';

--- a/src/components/select/select.nextjs.mdx
+++ b/src/components/select/select.nextjs.mdx
@@ -22,7 +22,7 @@ export default function Demo() {
 	const [ value, setValue ] = useState< string | undefined >();
 	return (
 		<Select value={ value } onChange={ ( v ) => setValue( v as string ) }>
-			<SelectButton placeholder="Pick a color" />
+			<SelectButton label="Color" placeholder="Pick a color" />
 			<SelectOptions>
 				<SelectOption value="red">Red</SelectOption>
 				<SelectOption value="green">Green</SelectOption>
@@ -43,7 +43,7 @@ Inside your own client components the familiar compound dot syntax still works â
 import { Select } from '@bsf/force-ui';
 
 <Select value={ value } onChange={ setValue }>
-	<Select.Button placeholder="Pick a color" />
+	<Select.Button label="Color" placeholder="Pick a color" />
 	<Select.Options>
 		<Select.Option value="red">Red</Select.Option>
 	</Select.Options>

--- a/src/components/select/select.nextjs.mdx
+++ b/src/components/select/select.nextjs.mdx
@@ -1,0 +1,61 @@
+import { Meta, Canvas } from '@storybook/addon-docs/blocks';
+import * as Stories from './select-atom.stories';
+import * as NextjsStories from './select.nextjs.stories';
+
+<Meta of={Stories} name="Next.js Usage" />
+
+# Select — Next.js (App Router)
+
+`Select` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box and can render inside a **Server Component**.
+
+## Usage in a Server Component
+
+Use the **named subpart exports** — not dot access (`Select.X`). In a Server Component, React cannot read sub-components attached to a client reference, so dot access resolves to `undefined`. The named exports are individual client references:
+
+```tsx
+// app/select-demo.tsx
+'use client';
+import { useState } from 'react';
+import { Select, SelectButton, SelectOptions, SelectOption } from '@bsf/force-ui';
+
+export default function Demo() {
+	const [ value, setValue ] = useState< string | undefined >();
+	return (
+		<Select value={ value } onChange={ ( v ) => setValue( v as string ) }>
+			<SelectButton placeholder="Pick a color" />
+			<SelectOptions>
+				<SelectOption value="red">Red</SelectOption>
+				<SelectOption value="green">Green</SelectOption>
+			</SelectOptions>
+		</Select>
+	);
+}
+```
+
+> `Select.Option` is exported as **`SelectOption`** (alias of `SelectItem`).
+
+## Dot notation (client components only)
+
+Inside your own client components the familiar compound dot syntax still works — it is only Server Components that require the named exports above:
+
+```tsx
+'use client';
+import { Select } from '@bsf/force-ui';
+
+<Select value={ value } onChange={ setValue }>
+	<Select.Button placeholder="Pick a color" />
+	<Select.Options>
+		<Select.Option value="red">Red</Select.Option>
+	</Select.Options>
+</Select>
+```
+
+## Notes
+
+- The `onChange` handler must live in a client component — handlers cannot be passed from a Server Component.
+
+## Live preview
+
+_Rendered with the named (App-Router) pattern. Use **Show code** to copy it._
+
+<Canvas of={NextjsStories.ServerComponentPattern} />

--- a/src/components/select/select.nextjs.mdx
+++ b/src/components/select/select.nextjs.mdx
@@ -6,7 +6,7 @@ import * as NextjsStories from './select.nextjs.stories';
 
 # Select — Next.js (App Router)
 
-`Select` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box and can render inside a **Server Component**.
+> **TL;DR** — `Select` works in the Next.js App Router out of the box: import it and render it inside a **Server Component**. Use its named subpart exports (e.g. `SelectButton`) — not dot notation (`Select.X`). Put anything interactive (event handlers, state) in a file that starts with `'use client'`.
 
 ## Usage in a Server Component
 
@@ -56,6 +56,6 @@ import { Select } from '@bsf/force-ui';
 
 ## Live preview
 
-_Rendered with the named (App-Router) pattern. Use **Show code** to copy it._
+_Rendered with the named (App-Router) pattern._
 
 <Canvas of={NextjsStories.ServerComponentPattern} />

--- a/src/components/select/select.nextjs.stories.tsx
+++ b/src/components/select/select.nextjs.stories.tsx
@@ -9,7 +9,7 @@ const meta: Meta = {
 	title: 'Atoms/Select/Next.js Example',
 	component: Select,
 	tags: [ '!dev', '!autodocs' ],
-	parameters: { layout: 'padded' },
+	parameters: { layout: 'centered' },
 };
 
 export default meta;
@@ -20,13 +20,15 @@ export const ServerComponentPattern: StoryObj = {
 		// eslint-disable-next-line react-hooks/rules-of-hooks
 		const [ value, setValue ] = useState< string | undefined >();
 		return (
-			<Select value={ value } onChange={ ( v ) => setValue( v as string ) }>
-				<SelectButton placeholder="Pick a color" />
-				<SelectOptions>
-					<SelectOption value="red">Red</SelectOption>
-					<SelectOption value="green">Green</SelectOption>
-				</SelectOptions>
-			</Select>
+			<div className="w-full max-w-sm h-[220px]">
+				<Select value={ value } onChange={ ( v ) => setValue( v as string ) }>
+					<SelectButton placeholder="Pick a color" />
+					<SelectOptions>
+						<SelectOption value="red">Red</SelectOption>
+						<SelectOption value="green">Green</SelectOption>
+					</SelectOptions>
+				</Select>
+			</div>
 		);
 	},
 };

--- a/src/components/select/select.nextjs.stories.tsx
+++ b/src/components/select/select.nextjs.stories.tsx
@@ -22,7 +22,7 @@ export const ServerComponentPattern: StoryObj = {
 		return (
 			<div className="w-full max-w-sm h-[220px]">
 				<Select value={ value } onChange={ ( v ) => setValue( v as string ) }>
-					<SelectButton placeholder="Pick a color" />
+					<SelectButton label="Color" placeholder="Pick a color" />
 					<SelectOptions>
 						<SelectOption value="red">Red</SelectOption>
 						<SelectOption value="green">Green</SelectOption>

--- a/src/components/select/select.nextjs.stories.tsx
+++ b/src/components/select/select.nextjs.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+import { Select, SelectButton, SelectOptions, SelectOption } from '@/components';
+
+// Powers the "Next.js Usage" docs <Canvas>. Hidden from the sidebar
+// (`!dev`) and excluded from autodocs — it only demonstrates the named
+// (App-Router) import pattern in an isolated preview with copyable code.
+const meta: Meta = {
+	title: 'Atoms/Select/Next.js Example',
+	component: Select,
+	tags: [ '!dev', '!autodocs' ],
+	parameters: { layout: 'padded' },
+};
+
+export default meta;
+
+export const ServerComponentPattern: StoryObj = {
+	name: 'Named exports (App Router)',
+	render: () => {
+		// eslint-disable-next-line react-hooks/rules-of-hooks
+		const [ value, setValue ] = useState< string | undefined >();
+		return (
+			<Select value={ value } onChange={ ( v ) => setValue( v as string ) }>
+				<SelectButton placeholder="Pick a color" />
+				<SelectOptions>
+					<SelectOption value="red">Red</SelectOption>
+					<SelectOption value="green">Green</SelectOption>
+				</SelectOptions>
+			</Select>
+		);
+	},
+};

--- a/src/components/select/select.tsx
+++ b/src/components/select/select.tsx
@@ -1,3 +1,4 @@
+'use client';
 import {
 	useState,
 	useCallback,

--- a/src/components/sidebar/index.ts
+++ b/src/components/sidebar/index.ts
@@ -1,1 +1,7 @@
 export { default } from './sidebar';
+export {
+	SidebarHeader,
+	SidebarBody,
+	SidebarFooter,
+	SidebarItem,
+} from './sidebar';

--- a/src/components/sidebar/sidebar.nextjs.mdx
+++ b/src/components/sidebar/sidebar.nextjs.mdx
@@ -1,0 +1,58 @@
+import { Meta, Canvas } from '@storybook/addon-docs/blocks';
+import * as Stories from './sidebar.stories';
+import * as NextjsStories from './sidebar.nextjs.stories';
+
+<Meta of={Stories} name="Next.js Usage" />
+
+# Sidebar — Next.js (App Router)
+
+`Sidebar` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box and can render inside a **Server Component**.
+
+## Usage in a Server Component
+
+Use the **named subpart exports** — not dot access (`Sidebar.X`). In a Server Component, React cannot read sub-components attached to a client reference, so dot access resolves to `undefined`. The named exports are individual client references:
+
+```tsx
+// app/page.tsx — Server Component
+import { Sidebar, SidebarHeader, SidebarBody, SidebarFooter, SidebarItem } from '@bsf/force-ui';
+
+export default function Page() {
+	return (
+		<Sidebar>
+			<SidebarHeader>Logo</SidebarHeader>
+			<SidebarBody>
+				<SidebarItem>Dashboard</SidebarItem>
+				<SidebarItem>Settings</SidebarItem>
+			</SidebarBody>
+			<SidebarFooter>v1.7.13</SidebarFooter>
+		</Sidebar>
+	);
+}
+```
+
+## Dot notation (client components only)
+
+Inside your own client components the familiar compound dot syntax still works — it is only Server Components that require the named exports above:
+
+```tsx
+'use client';
+import { Sidebar } from '@bsf/force-ui';
+
+<Sidebar>
+	<Sidebar.Header>Logo</Sidebar.Header>
+	<Sidebar.Body>
+		<Sidebar.Item>Dashboard</Sidebar.Item>
+	</Sidebar.Body>
+	<Sidebar.Footer>v1</Sidebar.Footer>
+</Sidebar>
+```
+
+## Notes
+
+- SSR-safe: the initial collapsed state is guarded with `typeof window === 'undefined'`, then corrected on mount, so it renders in Server Components without touching `window`.
+
+## Live preview
+
+_Rendered with the named (App-Router) pattern. Use **Show code** to copy it._
+
+<Canvas of={NextjsStories.ServerComponentPattern} />

--- a/src/components/sidebar/sidebar.nextjs.mdx
+++ b/src/components/sidebar/sidebar.nextjs.mdx
@@ -6,7 +6,7 @@ import * as NextjsStories from './sidebar.nextjs.stories';
 
 # Sidebar — Next.js (App Router)
 
-`Sidebar` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box and can render inside a **Server Component**.
+> **TL;DR** — `Sidebar` works in the Next.js App Router out of the box: import it and render it inside a **Server Component**. Use its named subpart exports (e.g. `SidebarHeader`) — not dot notation (`Sidebar.X`). Put anything interactive (event handlers, state) in a file that starts with `'use client'`.
 
 ## Usage in a Server Component
 
@@ -51,8 +51,24 @@ import { Sidebar } from '@bsf/force-ui';
 
 - SSR-safe: the initial collapsed state is guarded with `typeof window === 'undefined'`, then corrected on mount, so it renders in Server Components without touching `window`.
 
+## Event handlers & state
+
+Server Components can't hold state or receive event handlers (`onClick`, `onChange`, …). Move the interactive part into its own client component:
+
+```tsx
+'use client';
+import { Sidebar } from '@bsf/force-ui';
+
+export default function Interactive() {
+	// useState, onClick, onChange … live in this client file
+	return <Sidebar />;
+}
+```
+
+Then import that into your Server Component — the page itself stays a Server Component.
+
 ## Live preview
 
-_Rendered with the named (App-Router) pattern. Use **Show code** to copy it._
+_Rendered with the named (App-Router) pattern._
 
 <Canvas of={NextjsStories.ServerComponentPattern} />

--- a/src/components/sidebar/sidebar.nextjs.stories.tsx
+++ b/src/components/sidebar/sidebar.nextjs.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Sidebar, SidebarHeader, SidebarBody, SidebarFooter, SidebarItem } from '@/components';
+
+// Powers the "Next.js Usage" docs <Canvas>. Hidden from the sidebar
+// (`!dev`) and excluded from autodocs — it only demonstrates the named
+// (App-Router) import pattern in an isolated preview with copyable code.
+const meta: Meta = {
+	title: 'Organisms/Sidebar/Next.js Example',
+	component: Sidebar,
+	tags: [ '!dev', '!autodocs' ],
+	parameters: { layout: 'padded' },
+};
+
+export default meta;
+
+export const ServerComponentPattern: StoryObj = {
+	name: 'Named exports (App Router)',
+	render: () => {
+		return (
+			<div style={ { height: 220 } }>
+				<Sidebar>
+					<SidebarHeader>Logo</SidebarHeader>
+					<SidebarBody>
+						<SidebarItem>Dashboard</SidebarItem>
+						<SidebarItem>Settings</SidebarItem>
+					</SidebarBody>
+					<SidebarFooter>v1.7.13</SidebarFooter>
+				</Sidebar>
+			</div>
+		);
+	},
+};

--- a/src/components/sidebar/sidebar.nextjs.stories.tsx
+++ b/src/components/sidebar/sidebar.nextjs.stories.tsx
@@ -8,7 +8,7 @@ const meta: Meta = {
 	title: 'Organisms/Sidebar/Next.js Example',
 	component: Sidebar,
 	tags: [ '!dev', '!autodocs' ],
-	parameters: { layout: 'padded' },
+	parameters: { layout: 'fullscreen' },
 };
 
 export default meta;
@@ -17,7 +17,7 @@ export const ServerComponentPattern: StoryObj = {
 	name: 'Named exports (App Router)',
 	render: () => {
 		return (
-			<div style={ { height: 220 } }>
+			<div className="h-[340px]">
 				<Sidebar>
 					<SidebarHeader>Logo</SidebarHeader>
 					<SidebarBody>

--- a/src/components/sidebar/sidebar.tsx
+++ b/src/components/sidebar/sidebar.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React, {
 	type ReactNode,
 	createContext,
@@ -67,6 +68,9 @@ export const Sidebar = ( {
 		const storedState = safeLocalStorage.get( 'sidebar-collapsed' );
 		if ( storedState ) {
 			return storedState;
+		}
+		if ( typeof window === 'undefined' ) {
+			return collapsed;
 		}
 		const isSmallScreen = window.innerWidth < 1280;
 		return isSmallScreen;

--- a/src/components/skeleton/skeleton.nextjs.mdx
+++ b/src/components/skeleton/skeleton.nextjs.mdx
@@ -5,7 +5,7 @@ import * as Stories from './skeleton.stories';
 
 # Skeleton — Next.js (App Router)
 
-`Skeleton` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box. Import it and render it directly inside a **Server Component**.
+> **TL;DR** — `Skeleton` works in the Next.js App Router out of the box: import it and render it inside a **Server Component**. Put anything interactive (event handlers, state) in a file that starts with `'use client'`.
 
 ## Usage in a Server Component
 
@@ -17,6 +17,22 @@ export default function Page() {
 	return <Skeleton />;
 }
 ```
+
+## Event handlers & state
+
+Server Components can't hold state or receive event handlers (`onClick`, `onChange`, …). Move the interactive part into its own client component:
+
+```tsx
+'use client';
+import { Skeleton } from '@bsf/force-ui';
+
+export default function Interactive() {
+	// useState, onClick, onChange … live in this client file
+	return <Skeleton />;
+}
+```
+
+Then import that into your Server Component — the page itself stays a Server Component.
 
 ## Live preview
 

--- a/src/components/skeleton/skeleton.nextjs.mdx
+++ b/src/components/skeleton/skeleton.nextjs.mdx
@@ -1,0 +1,23 @@
+import { Meta, Canvas } from '@storybook/addon-docs/blocks';
+import * as Stories from './skeleton.stories';
+
+<Meta of={Stories} name="Next.js Usage" />
+
+# Skeleton — Next.js (App Router)
+
+`Skeleton` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box. Import it and render it directly inside a **Server Component**.
+
+## Usage in a Server Component
+
+```tsx
+// app/page.tsx — Server Component
+import { Skeleton } from '@bsf/force-ui';
+
+export default function Page() {
+	return <Skeleton />;
+}
+```
+
+## Live preview
+
+<Canvas of={Stories.Rectangular} />

--- a/src/components/skeleton/skeleton.tsx
+++ b/src/components/skeleton/skeleton.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { cn } from '@/utilities/functions';
 
 export interface SkeletonProps {

--- a/src/components/switch/switch.nextjs.mdx
+++ b/src/components/switch/switch.nextjs.mdx
@@ -1,0 +1,27 @@
+import { Meta, Canvas } from '@storybook/addon-docs/blocks';
+import * as Stories from './switch.stories';
+
+<Meta of={Stories} name="Next.js Usage" />
+
+# Switch — Next.js (App Router)
+
+`Switch` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box. Import it and render it directly inside a **Server Component**.
+
+## Usage in a Server Component
+
+```tsx
+// app/page.tsx — Server Component
+import { Switch } from '@bsf/force-ui';
+
+export default function Page() {
+	return <Switch />;
+}
+```
+
+## Notes
+
+- Value/`onChange` handlers must be defined in a client component.
+
+## Live preview
+
+<Canvas of={Stories.Basic} />

--- a/src/components/switch/switch.nextjs.mdx
+++ b/src/components/switch/switch.nextjs.mdx
@@ -5,7 +5,7 @@ import * as Stories from './switch.stories';
 
 # Switch — Next.js (App Router)
 
-`Switch` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box. Import it and render it directly inside a **Server Component**.
+> **TL;DR** — `Switch` works in the Next.js App Router out of the box: import it and render it inside a **Server Component**. Put anything interactive (event handlers, state) in a file that starts with `'use client'`.
 
 ## Usage in a Server Component
 
@@ -21,6 +21,22 @@ export default function Page() {
 ## Notes
 
 - Value/`onChange` handlers must be defined in a client component.
+
+## Event handlers & state
+
+Server Components can't hold state or receive event handlers (`onClick`, `onChange`, …). Move the interactive part into its own client component:
+
+```tsx
+'use client';
+import { Switch } from '@bsf/force-ui';
+
+export default function Interactive() {
+	// useState, onClick, onChange … live in this client file
+	return <Switch />;
+}
+```
+
+Then import that into your Server Component — the page itself stays a Server Component.
 
 ## Live preview
 

--- a/src/components/switch/switch.tsx
+++ b/src/components/switch/switch.tsx
@@ -1,3 +1,4 @@
+'use client';
 import {
 	useState,
 	useMemo,

--- a/src/components/table/index.ts
+++ b/src/components/table/index.ts
@@ -1,1 +1,9 @@
 export { default } from './table';
+export {
+	TableHead,
+	TableHeadCell,
+	TableBody,
+	TableRow,
+	TableCell,
+	TableFooter,
+} from './table';

--- a/src/components/table/table.nextjs.mdx
+++ b/src/components/table/table.nextjs.mdx
@@ -1,0 +1,53 @@
+import { Meta, Canvas } from '@storybook/addon-docs/blocks';
+import * as Stories from './table.stories';
+import * as NextjsStories from './table.nextjs.stories';
+
+<Meta of={Stories} name="Next.js Usage" />
+
+# Table — Next.js (App Router)
+
+`Table` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box and can render inside a **Server Component**.
+
+## Usage in a Server Component
+
+Use the **named subpart exports** — not dot access (`Table.X`). In a Server Component, React cannot read sub-components attached to a client reference, so dot access resolves to `undefined`. The named exports are individual client references:
+
+```tsx
+// app/page.tsx — Server Component
+import { Table, TableHead, TableHeadCell, TableBody, TableRow, TableCell } from '@bsf/force-ui';
+
+export default function Page() {
+	return (
+		<Table>
+			<TableHead>
+				<TableHeadCell>Name</TableHeadCell>
+				<TableHeadCell>Role</TableHeadCell>
+			</TableHead>
+			<TableBody>
+				<TableRow><TableCell>Ada</TableCell><TableCell>Engineer</TableCell></TableRow>
+				<TableRow><TableCell>Linus</TableCell><TableCell>Maintainer</TableCell></TableRow>
+			</TableBody>
+		</Table>
+	);
+}
+```
+
+## Dot notation (client components only)
+
+Inside your own client components the familiar compound dot syntax still works — it is only Server Components that require the named exports above:
+
+```tsx
+'use client';
+import { Table } from '@bsf/force-ui';
+
+<Table>
+	<Table.Head><Table.HeadCell>Name</Table.HeadCell></Table.Head>
+	<Table.Body><Table.Row><Table.Cell>Ada</Table.Cell></Table.Row></Table.Body>
+</Table>
+```
+
+## Live preview
+
+_Rendered with the named (App-Router) pattern. Use **Show code** to copy it._
+
+<Canvas of={NextjsStories.ServerComponentPattern} />

--- a/src/components/table/table.nextjs.mdx
+++ b/src/components/table/table.nextjs.mdx
@@ -6,7 +6,7 @@ import * as NextjsStories from './table.nextjs.stories';
 
 # Table — Next.js (App Router)
 
-`Table` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box and can render inside a **Server Component**.
+> **TL;DR** — `Table` works in the Next.js App Router out of the box: import it and render it inside a **Server Component**. Use its named subpart exports (e.g. `TableHead`) — not dot notation (`Table.X`). Put anything interactive (event handlers, state) in a file that starts with `'use client'`.
 
 ## Usage in a Server Component
 
@@ -46,8 +46,24 @@ import { Table } from '@bsf/force-ui';
 </Table>
 ```
 
+## Event handlers & state
+
+Server Components can't hold state or receive event handlers (`onClick`, `onChange`, …). Move the interactive part into its own client component:
+
+```tsx
+'use client';
+import { Table } from '@bsf/force-ui';
+
+export default function Interactive() {
+	// useState, onClick, onChange … live in this client file
+	return <Table />;
+}
+```
+
+Then import that into your Server Component — the page itself stays a Server Component.
+
 ## Live preview
 
-_Rendered with the named (App-Router) pattern. Use **Show code** to copy it._
+_Rendered with the named (App-Router) pattern._
 
 <Canvas of={NextjsStories.ServerComponentPattern} />

--- a/src/components/table/table.nextjs.stories.tsx
+++ b/src/components/table/table.nextjs.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Table, TableHead, TableHeadCell, TableBody, TableRow, TableCell } from '@/components';
+
+// Powers the "Next.js Usage" docs <Canvas>. Hidden from the sidebar
+// (`!dev`) and excluded from autodocs — it only demonstrates the named
+// (App-Router) import pattern in an isolated preview with copyable code.
+const meta: Meta = {
+	title: 'Atoms/Table/Next.js Example',
+	component: Table,
+	tags: [ '!dev', '!autodocs' ],
+	parameters: { layout: 'padded' },
+};
+
+export default meta;
+
+export const ServerComponentPattern: StoryObj = {
+	name: 'Named exports (App Router)',
+	render: () => {
+		return (
+			<Table>
+				<TableHead>
+					<TableHeadCell>Name</TableHeadCell>
+					<TableHeadCell>Role</TableHeadCell>
+				</TableHead>
+				<TableBody>
+					<TableRow><TableCell>Ada</TableCell><TableCell>Engineer</TableCell></TableRow>
+					<TableRow><TableCell>Linus</TableCell><TableCell>Maintainer</TableCell></TableRow>
+				</TableBody>
+			</Table>
+		);
+	},
+};

--- a/src/components/table/table.nextjs.stories.tsx
+++ b/src/components/table/table.nextjs.stories.tsx
@@ -17,16 +17,18 @@ export const ServerComponentPattern: StoryObj = {
 	name: 'Named exports (App Router)',
 	render: () => {
 		return (
-			<Table>
-				<TableHead>
-					<TableHeadCell>Name</TableHeadCell>
-					<TableHeadCell>Role</TableHeadCell>
-				</TableHead>
-				<TableBody>
-					<TableRow><TableCell>Ada</TableCell><TableCell>Engineer</TableCell></TableRow>
-					<TableRow><TableCell>Linus</TableCell><TableCell>Maintainer</TableCell></TableRow>
-				</TableBody>
-			</Table>
+			<div className="w-full">
+				<Table>
+					<TableHead>
+						<TableHeadCell>Name</TableHeadCell>
+						<TableHeadCell>Role</TableHeadCell>
+					</TableHead>
+					<TableBody>
+						<TableRow><TableCell>Ada</TableCell><TableCell>Engineer</TableCell></TableRow>
+						<TableRow><TableCell>Linus</TableCell><TableCell>Maintainer</TableCell></TableRow>
+					</TableBody>
+				</Table>
+			</div>
 		);
 	},
 };

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { cn } from '@/utilities/functions';
 import React, {
 	Children,

--- a/src/components/tabs/index.ts
+++ b/src/components/tabs/index.ts
@@ -1,1 +1,6 @@
 export { default } from './tabs';
+export {
+	TabsGroup,
+	Tab as TabsTab,
+	TabPanel as TabsPanel,
+} from './tabs';

--- a/src/components/tabs/tabs.nextjs.mdx
+++ b/src/components/tabs/tabs.nextjs.mdx
@@ -6,7 +6,7 @@ import * as NextjsStories from './tabs.nextjs.stories';
 
 # Tabs — Next.js (App Router)
 
-`Tabs` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box and can render inside a **Server Component**.
+> **TL;DR** — `Tabs` works in the Next.js App Router out of the box: import it and render it inside a **Server Component**. Use its named subpart exports (e.g. `TabsGroup`) — not dot notation (`Tabs.X`). Put anything interactive (event handlers, state) in a file that starts with `'use client'`.
 
 ## Usage in a Server Component
 
@@ -57,6 +57,6 @@ import { Tabs } from '@bsf/force-ui';
 
 ## Live preview
 
-_Rendered with the named (App-Router) pattern. Use **Show code** to copy it._
+_Rendered with the named (App-Router) pattern._
 
 <Canvas of={NextjsStories.ServerComponentPattern} />

--- a/src/components/tabs/tabs.nextjs.mdx
+++ b/src/components/tabs/tabs.nextjs.mdx
@@ -1,0 +1,62 @@
+import { Meta, Canvas } from '@storybook/addon-docs/blocks';
+import * as Stories from './tabs.stories';
+import * as NextjsStories from './tabs.nextjs.stories';
+
+<Meta of={Stories} name="Next.js Usage" />
+
+# Tabs — Next.js (App Router)
+
+`Tabs` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box and can render inside a **Server Component**.
+
+## Usage in a Server Component
+
+Use the **named subpart exports** — not dot access (`Tabs.X`). In a Server Component, React cannot read sub-components attached to a client reference, so dot access resolves to `undefined`. The named exports are individual client references:
+
+```tsx
+// app/tabs-demo.tsx
+'use client';
+import { useState } from 'react';
+import { Tabs, TabsGroup, TabsTab, TabsPanel } from '@bsf/force-ui';
+
+export default function Demo() {
+	const [ active, setActive ] = useState( 'a' );
+	return (
+		<Tabs activeItem={ active }>
+			<TabsGroup activeItem={ active } onChange={ ( { value } ) => setActive( value.slug ) }>
+				<TabsTab slug="a" text="Tab A" />
+				<TabsTab slug="b" text="Tab B" />
+			</TabsGroup>
+			<TabsPanel slug="a">Panel A</TabsPanel>
+			<TabsPanel slug="b">Panel B</TabsPanel>
+		</Tabs>
+	);
+}
+```
+
+> `Tabs.Tab` / `Tabs.Panel` are exported as **`TabsTab`** / **`TabsPanel`**.
+
+## Dot notation (client components only)
+
+Inside your own client components the familiar compound dot syntax still works — it is only Server Components that require the named exports above:
+
+```tsx
+'use client';
+import { Tabs } from '@bsf/force-ui';
+
+<Tabs activeItem={ active }>
+	<Tabs.Group activeItem={ active } onChange={ handleChange }>
+		<Tabs.Tab slug="a" text="Tab A" />
+	</Tabs.Group>
+	<Tabs.Panel slug="a">Panel A</Tabs.Panel>
+</Tabs>
+```
+
+## Notes
+
+- The active tab state (`activeItem` / `onChange`) lives in a client component.
+
+## Live preview
+
+_Rendered with the named (App-Router) pattern. Use **Show code** to copy it._
+
+<Canvas of={NextjsStories.ServerComponentPattern} />

--- a/src/components/tabs/tabs.nextjs.stories.tsx
+++ b/src/components/tabs/tabs.nextjs.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+import { Tabs, TabsGroup, TabsTab, TabsPanel } from '@/components';
+
+// Powers the "Next.js Usage" docs <Canvas>. Hidden from the sidebar
+// (`!dev`) and excluded from autodocs — it only demonstrates the named
+// (App-Router) import pattern in an isolated preview with copyable code.
+const meta: Meta = {
+	title: 'Atoms/Tabs/Next.js Example',
+	component: Tabs,
+	tags: [ '!dev', '!autodocs' ],
+	parameters: { layout: 'padded' },
+};
+
+export default meta;
+
+export const ServerComponentPattern: StoryObj = {
+	name: 'Named exports (App Router)',
+	render: () => {
+		// eslint-disable-next-line react-hooks/rules-of-hooks
+		const [ active, setActive ] = useState( 'a' );
+		return (
+			<Tabs activeItem={ active }>
+				<TabsGroup activeItem={ active } onChange={ ( { value } ) => setActive( value.slug ) }>
+					<TabsTab slug="a" text="Tab A" />
+					<TabsTab slug="b" text="Tab B" />
+				</TabsGroup>
+				<TabsPanel slug="a">Panel A</TabsPanel>
+				<TabsPanel slug="b">Panel B</TabsPanel>
+			</Tabs>
+		);
+	},
+};

--- a/src/components/tabs/tabs.nextjs.stories.tsx
+++ b/src/components/tabs/tabs.nextjs.stories.tsx
@@ -9,7 +9,7 @@ const meta: Meta = {
 	title: 'Atoms/Tabs/Next.js Example',
 	component: Tabs,
 	tags: [ '!dev', '!autodocs' ],
-	parameters: { layout: 'padded' },
+	parameters: { layout: 'centered' },
 };
 
 export default meta;
@@ -20,14 +20,16 @@ export const ServerComponentPattern: StoryObj = {
 		// eslint-disable-next-line react-hooks/rules-of-hooks
 		const [ active, setActive ] = useState( 'a' );
 		return (
-			<Tabs activeItem={ active }>
-				<TabsGroup activeItem={ active } onChange={ ( { value } ) => setActive( value.slug ) }>
-					<TabsTab slug="a" text="Tab A" />
-					<TabsTab slug="b" text="Tab B" />
-				</TabsGroup>
-				<TabsPanel slug="a">Panel A</TabsPanel>
-				<TabsPanel slug="b">Panel B</TabsPanel>
-			</Tabs>
+			<div className="w-full max-w-lg">
+				<Tabs activeItem={ active }>
+					<TabsGroup activeItem={ active } onChange={ ( { value } ) => setActive( value.slug ) }>
+						<TabsTab slug="a" text="Tab A" />
+						<TabsTab slug="b" text="Tab B" />
+					</TabsGroup>
+					<TabsPanel slug="a">Panel A</TabsPanel>
+					<TabsPanel slug="b">Panel B</TabsPanel>
+				</Tabs>
+			</div>
 		);
 	},
 };

--- a/src/components/tabs/tabs.tsx
+++ b/src/components/tabs/tabs.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React, {
 	useCallback,
 	useMemo,

--- a/src/components/text/text.nextjs.mdx
+++ b/src/components/text/text.nextjs.mdx
@@ -5,7 +5,7 @@ import * as Stories from './text.stories';
 
 # Text — Next.js (App Router)
 
-`Text` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box. Import it and render it directly inside a **Server Component**.
+> **TL;DR** — `Text` works in the Next.js App Router out of the box: import it and render it inside a **Server Component**. Put anything interactive (event handlers, state) in a file that starts with `'use client'`.
 
 ## Usage in a Server Component
 
@@ -17,6 +17,22 @@ export default function Page() {
 	return <Text />;
 }
 ```
+
+## Event handlers & state
+
+Server Components can't hold state or receive event handlers (`onClick`, `onChange`, …). Move the interactive part into its own client component:
+
+```tsx
+'use client';
+import { Text } from '@bsf/force-ui';
+
+export default function Interactive() {
+	// useState, onClick, onChange … live in this client file
+	return <Text />;
+}
+```
+
+Then import that into your Server Component — the page itself stays a Server Component.
 
 ## Live preview
 

--- a/src/components/text/text.nextjs.mdx
+++ b/src/components/text/text.nextjs.mdx
@@ -1,0 +1,23 @@
+import { Meta, Canvas } from '@storybook/addon-docs/blocks';
+import * as Stories from './text.stories';
+
+<Meta of={Stories} name="Next.js Usage" />
+
+# Text — Next.js (App Router)
+
+`Text` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box. Import it and render it directly inside a **Server Component**.
+
+## Usage in a Server Component
+
+```tsx
+// app/page.tsx — Server Component
+import { Text } from '@bsf/force-ui';
+
+export default function Page() {
+	return <Text />;
+}
+```
+
+## Live preview
+
+<Canvas of={Stories.Default} />

--- a/src/components/text/text.tsx
+++ b/src/components/text/text.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { cn } from '@/utilities/functions';
 import {
 	fontColorClassNames,

--- a/src/components/textarea/textarea.nextjs.mdx
+++ b/src/components/textarea/textarea.nextjs.mdx
@@ -1,0 +1,27 @@
+import { Meta, Canvas } from '@storybook/addon-docs/blocks';
+import * as Stories from './textarea.stories';
+
+<Meta of={Stories} name="Next.js Usage" />
+
+# TextArea — Next.js (App Router)
+
+`TextArea` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box. Import it and render it directly inside a **Server Component**.
+
+## Usage in a Server Component
+
+```tsx
+// app/page.tsx — Server Component
+import { TextArea } from '@bsf/force-ui';
+
+export default function Page() {
+	return <TextArea />;
+}
+```
+
+## Notes
+
+- Value/`onChange` handlers must be defined in a client component.
+
+## Live preview
+
+<Canvas of={Stories.Basic} />

--- a/src/components/textarea/textarea.nextjs.mdx
+++ b/src/components/textarea/textarea.nextjs.mdx
@@ -5,7 +5,7 @@ import * as Stories from './textarea.stories';
 
 # TextArea — Next.js (App Router)
 
-`TextArea` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box. Import it and render it directly inside a **Server Component**.
+> **TL;DR** — `TextArea` works in the Next.js App Router out of the box: import it and render it inside a **Server Component**. Put anything interactive (event handlers, state) in a file that starts with `'use client'`.
 
 ## Usage in a Server Component
 
@@ -21,6 +21,22 @@ export default function Page() {
 ## Notes
 
 - Value/`onChange` handlers must be defined in a client component.
+
+## Event handlers & state
+
+Server Components can't hold state or receive event handlers (`onClick`, `onChange`, …). Move the interactive part into its own client component:
+
+```tsx
+'use client';
+import { TextArea } from '@bsf/force-ui';
+
+export default function Interactive() {
+	// useState, onClick, onChange … live in this client file
+	return <TextArea />;
+}
+```
+
+Then import that into your Server Component — the page itself stays a Server Component.
 
 ## Live preview
 

--- a/src/components/textarea/textarea.tsx
+++ b/src/components/textarea/textarea.tsx
@@ -1,3 +1,4 @@
+'use client';
 import {
 	useState,
 	useCallback,

--- a/src/components/title/title.nextjs.mdx
+++ b/src/components/title/title.nextjs.mdx
@@ -5,7 +5,7 @@ import * as Stories from './title.stories';
 
 # Title — Next.js (App Router)
 
-`Title` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box. Import it and render it directly inside a **Server Component**.
+> **TL;DR** — `Title` works in the Next.js App Router out of the box: import it and render it inside a **Server Component**. Put anything interactive (event handlers, state) in a file that starts with `'use client'`.
 
 ## Usage in a Server Component
 
@@ -17,6 +17,22 @@ export default function Page() {
 	return <Title />;
 }
 ```
+
+## Event handlers & state
+
+Server Components can't hold state or receive event handlers (`onClick`, `onChange`, …). Move the interactive part into its own client component:
+
+```tsx
+'use client';
+import { Title } from '@bsf/force-ui';
+
+export default function Interactive() {
+	// useState, onClick, onChange … live in this client file
+	return <Title />;
+}
+```
+
+Then import that into your Server Component — the page itself stays a Server Component.
 
 ## Live preview
 

--- a/src/components/title/title.nextjs.mdx
+++ b/src/components/title/title.nextjs.mdx
@@ -1,0 +1,23 @@
+import { Meta, Canvas } from '@storybook/addon-docs/blocks';
+import * as Stories from './title.stories';
+
+<Meta of={Stories} name="Next.js Usage" />
+
+# Title — Next.js (App Router)
+
+`Title` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box. Import it and render it directly inside a **Server Component**.
+
+## Usage in a Server Component
+
+```tsx
+// app/page.tsx — Server Component
+import { Title } from '@bsf/force-ui';
+
+export default function Page() {
+	return <Title />;
+}
+```
+
+## Live preview
+
+<Canvas of={Stories.Basic} />

--- a/src/components/title/title.tsx
+++ b/src/components/title/title.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { cn } from '@/utilities/functions';
 import { type ReactNode } from 'react';
 

--- a/src/components/toaster/controller.ts
+++ b/src/components/toaster/controller.ts
@@ -1,3 +1,4 @@
+'use client';
 import React from 'react';
 import type { ToastType, Subscriber } from './toaster-types';
 

--- a/src/components/toaster/toaster.nextjs.mdx
+++ b/src/components/toaster/toaster.nextjs.mdx
@@ -1,0 +1,31 @@
+import { Meta, Canvas } from '@storybook/addon-docs/blocks';
+import * as Stories from './toaster.stories';
+
+<Meta of={Stories} name="Next.js Usage" />
+
+# Toaster — Next.js (App Router)
+
+`Toaster` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box. Import it and render it directly inside a **Server Component**.
+
+## Usage in a Server Component
+
+Render the `<Toaster />` provider once in a client boundary; call `toast()` from client event handlers.
+
+```tsx
+// app/providers.tsx
+'use client';
+import { Toaster, toast } from '@bsf/force-ui';
+
+export function Providers( { children } ) {
+	return (
+		<>
+			{ children }
+			<Toaster />
+		</>
+	);
+}
+```
+
+## Live preview
+
+<Canvas of={Stories.Default} />

--- a/src/components/toaster/toaster.nextjs.mdx
+++ b/src/components/toaster/toaster.nextjs.mdx
@@ -5,7 +5,7 @@ import * as Stories from './toaster.stories';
 
 # Toaster — Next.js (App Router)
 
-`Toaster` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box. Import it and render it directly inside a **Server Component**.
+> **TL;DR** — `Toaster` works in the Next.js App Router out of the box: import it and render it inside a **Server Component**. Put anything interactive (event handlers, state) in a file that starts with `'use client'`.
 
 ## Usage in a Server Component
 

--- a/src/components/toaster/toaster.tsx
+++ b/src/components/toaster/toaster.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { useEffect, useRef, useState } from 'react';
 import { X } from 'lucide-react';
 import { ToastState } from './controller';

--- a/src/components/tooltip/tooltip.nextjs.mdx
+++ b/src/components/tooltip/tooltip.nextjs.mdx
@@ -5,7 +5,7 @@ import * as Stories from './tooltip.stories';
 
 # Tooltip — Next.js (App Router)
 
-`Tooltip` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box. Import it and render it directly inside a **Server Component**.
+> **TL;DR** — `Tooltip` works in the Next.js App Router out of the box: import it and render it inside a **Server Component**. Put anything interactive (event handlers, state) in a file that starts with `'use client'`.
 
 ## Usage in a Server Component
 
@@ -17,6 +17,22 @@ export default function Page() {
 	return <Tooltip />;
 }
 ```
+
+## Event handlers & state
+
+Server Components can't hold state or receive event handlers (`onClick`, `onChange`, …). Move the interactive part into its own client component:
+
+```tsx
+'use client';
+import { Tooltip } from '@bsf/force-ui';
+
+export default function Interactive() {
+	// useState, onClick, onChange … live in this client file
+	return <Tooltip />;
+}
+```
+
+Then import that into your Server Component — the page itself stays a Server Component.
 
 ## Live preview
 

--- a/src/components/tooltip/tooltip.nextjs.mdx
+++ b/src/components/tooltip/tooltip.nextjs.mdx
@@ -1,0 +1,23 @@
+import { Meta, Canvas } from '@storybook/addon-docs/blocks';
+import * as Stories from './tooltip.stories';
+
+<Meta of={Stories} name="Next.js Usage" />
+
+# Tooltip — Next.js (App Router)
+
+`Tooltip` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box. Import it and render it directly inside a **Server Component**.
+
+## Usage in a Server Component
+
+```tsx
+// app/page.tsx — Server Component
+import { Tooltip } from '@bsf/force-ui';
+
+export default function Page() {
+	return <Tooltip />;
+}
+```
+
+## Live preview
+
+<Canvas of={Stories.TooltipWithIcon} />

--- a/src/components/tooltip/tooltip.tsx
+++ b/src/components/tooltip/tooltip.tsx
@@ -1,3 +1,4 @@
+'use client';
 import {
 	useRef,
 	type ReactNode,

--- a/src/components/topbar/index.ts
+++ b/src/components/topbar/index.ts
@@ -1,1 +1,7 @@
 export { default } from './topbar';
+export {
+	Left as TopbarLeft,
+	Middle as TopbarMiddle,
+	Right as TopbarRight,
+	Item as TopbarItem,
+} from './topbar';

--- a/src/components/topbar/topbar.nextjs.mdx
+++ b/src/components/topbar/topbar.nextjs.mdx
@@ -6,7 +6,7 @@ import * as NextjsStories from './topbar.nextjs.stories';
 
 # Topbar — Next.js (App Router)
 
-`Topbar` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box and can render inside a **Server Component**.
+> **TL;DR** — `Topbar` works in the Next.js App Router out of the box: import it and render it inside a **Server Component**. Use its named subpart exports (e.g. `TopbarLeft`) — not dot notation (`Topbar.X`). Put anything interactive (event handlers, state) in a file that starts with `'use client'`.
 
 ## Usage in a Server Component
 
@@ -43,8 +43,24 @@ import { Topbar } from '@bsf/force-ui';
 </Topbar>
 ```
 
+## Event handlers & state
+
+Server Components can't hold state or receive event handlers (`onClick`, `onChange`, …). Move the interactive part into its own client component:
+
+```tsx
+'use client';
+import { Topbar } from '@bsf/force-ui';
+
+export default function Interactive() {
+	// useState, onClick, onChange … live in this client file
+	return <Topbar />;
+}
+```
+
+Then import that into your Server Component — the page itself stays a Server Component.
+
 ## Live preview
 
-_Rendered with the named (App-Router) pattern. Use **Show code** to copy it._
+_Rendered with the named (App-Router) pattern._
 
 <Canvas of={NextjsStories.ServerComponentPattern} />

--- a/src/components/topbar/topbar.nextjs.mdx
+++ b/src/components/topbar/topbar.nextjs.mdx
@@ -1,0 +1,50 @@
+import { Meta, Canvas } from '@storybook/addon-docs/blocks';
+import * as Stories from './topbar.stories';
+import * as NextjsStories from './topbar.nextjs.stories';
+
+<Meta of={Stories} name="Next.js Usage" />
+
+# Topbar — Next.js (App Router)
+
+`Topbar` ships with the `"use client"` directive compiled into its `dist` chunk, so it works in the **Next.js App Router** out of the box and can render inside a **Server Component**.
+
+## Usage in a Server Component
+
+Use the **named subpart exports** — not dot access (`Topbar.X`). In a Server Component, React cannot read sub-components attached to a client reference, so dot access resolves to `undefined`. The named exports are individual client references:
+
+```tsx
+// app/page.tsx — Server Component
+import { Topbar, TopbarLeft, TopbarMiddle, TopbarRight, TopbarItem } from '@bsf/force-ui';
+
+export default function Page() {
+	return (
+		<Topbar>
+			<TopbarLeft><TopbarItem>Left</TopbarItem></TopbarLeft>
+			<TopbarMiddle><TopbarItem>Middle</TopbarItem></TopbarMiddle>
+			<TopbarRight><TopbarItem>Right</TopbarItem></TopbarRight>
+		</Topbar>
+	);
+}
+```
+
+> `Topbar.Left/Middle/Right/Item` are exported as **`TopbarLeft`, `TopbarMiddle`, `TopbarRight`, `TopbarItem`**.
+
+## Dot notation (client components only)
+
+Inside your own client components the familiar compound dot syntax still works — it is only Server Components that require the named exports above:
+
+```tsx
+'use client';
+import { Topbar } from '@bsf/force-ui';
+
+<Topbar>
+	<Topbar.Left><Topbar.Item>Left</Topbar.Item></Topbar.Left>
+	<Topbar.Right><Topbar.Item>Right</Topbar.Item></Topbar.Right>
+</Topbar>
+```
+
+## Live preview
+
+_Rendered with the named (App-Router) pattern. Use **Show code** to copy it._
+
+<Canvas of={NextjsStories.ServerComponentPattern} />

--- a/src/components/topbar/topbar.nextjs.stories.tsx
+++ b/src/components/topbar/topbar.nextjs.stories.tsx
@@ -8,7 +8,7 @@ const meta: Meta = {
 	title: 'Organisms/Topbar/Next.js Example',
 	component: Topbar,
 	tags: [ '!dev', '!autodocs' ],
-	parameters: { layout: 'padded' },
+	parameters: { layout: 'fullscreen' },
 };
 
 export default meta;

--- a/src/components/topbar/topbar.nextjs.stories.tsx
+++ b/src/components/topbar/topbar.nextjs.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Topbar, TopbarLeft, TopbarMiddle, TopbarRight, TopbarItem } from '@/components';
+
+// Powers the "Next.js Usage" docs <Canvas>. Hidden from the sidebar
+// (`!dev`) and excluded from autodocs — it only demonstrates the named
+// (App-Router) import pattern in an isolated preview with copyable code.
+const meta: Meta = {
+	title: 'Organisms/Topbar/Next.js Example',
+	component: Topbar,
+	tags: [ '!dev', '!autodocs' ],
+	parameters: { layout: 'padded' },
+};
+
+export default meta;
+
+export const ServerComponentPattern: StoryObj = {
+	name: 'Named exports (App Router)',
+	render: () => {
+		return (
+			<Topbar>
+				<TopbarLeft><TopbarItem>Left</TopbarItem></TopbarLeft>
+				<TopbarMiddle><TopbarItem>Middle</TopbarItem></TopbarMiddle>
+				<TopbarRight><TopbarItem>Right</TopbarItem></TopbarRight>
+			</Topbar>
+		);
+	},
+};

--- a/src/components/topbar/topbar.tsx
+++ b/src/components/topbar/topbar.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { type ReactNode } from 'react';
 import { cn, getGapClass } from '@/utilities/functions';
 

--- a/src/nextjs-guide.mdx
+++ b/src/nextjs-guide.mdx
@@ -1,0 +1,84 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Guides/Using force-ui with Next.js" />
+
+# Using force-ui with Next.js (App Router)
+
+How to use force-ui in a Next.js **App Router** project. Every component also has
+its own **"Next.js Usage"** tab with a ready-to-copy example.
+
+## Background: Server vs Client Components
+
+In the App Router, components are **Server Components** by default — they render on
+the server and ship no JavaScript. A **Client Component** runs in the browser and is
+required for anything interactive (state, effects, event handlers). You turn a file
+into a Client Component by adding `'use client'` as its very first line.
+
+## 1. Install & styles
+
+```bash
+npm install @bsf/force-ui
+```
+
+Import the stylesheet once, e.g. in `app/layout.tsx`:
+
+```tsx
+import '@bsf/force-ui/dist/tailwind.css';
+```
+
+## 2. Components work in Server Components out of the box
+
+Every force-ui component is already marked with `'use client'` internally, so you can
+import and render it directly inside a Server Component — no wrapper needed:
+
+```tsx
+// app/page.tsx — Server Component
+import { Button } from '@bsf/force-ui';
+
+export default function Page() {
+	return <Button>Hello</Button>;
+}
+```
+
+## 3. Interactivity goes in a client component
+
+Server Components can't hold state or receive event handlers (`onClick`, `onChange`, …).
+Put the interactive part in its own file that starts with `'use client'`:
+
+```tsx
+// app/save-button.tsx
+'use client';
+import { Button } from '@bsf/force-ui';
+
+export default function SaveButton() {
+	return <Button onClick={ () => console.log( 'saved' ) }>Save</Button>;
+}
+```
+
+Then import that into your Server Component page. The page stays a Server Component;
+only the small interactive "island" is a Client Component.
+
+> Put an event handler directly in a Server Component and you'll see:
+> **"Event handlers cannot be passed to Client Component props."**
+
+## 4. Compound components: use named exports in Server Components
+
+Some components are **compound** — they expose sub-parts (e.g. `Select.Button`,
+`Select.Options`). In a **Server Component**, the dot syntax does not work: React can't
+read sub-components attached to a client component across the server/client boundary,
+so `Select.Button` becomes `undefined` and you get:
+
+> **Error: Element type is invalid … but got: undefined.**
+
+Import each sub-part by its **named export** instead:
+
+```tsx
+import { Select, SelectButton, SelectOptions, SelectOption } from '@bsf/force-ui';
+```
+
+The dot syntax still works fine inside your own client components. Each component's
+**Next.js Usage** tab lists its named sub-parts.
+
+---
+
+Open any component's **Next.js Usage** tab for a copy-paste example.

--- a/src/utilities/functions.js
+++ b/src/utilities/functions.js
@@ -52,6 +52,9 @@ export const columnClasses = {
 };
 
 export const getOperatingSystem = () => {
+	if ( typeof window === 'undefined' ) {
+		return 'null';
+	}
 	const platform =
 		window.navigator?.userAgentData?.platform || window.navigator.platform;
 	const macosPlatforms = [


### PR DESCRIPTION
Related issue: brainstormforce/surerank#1860

## Summary

Adds **Next.js (React Server Components) compatibility** to force-ui. Components can now be imported and rendered directly inside Server Components in the App Router, and compound components expose named subpart exports so they work across the server/client boundary. Fully backward compatible (existing dot-notation usage in client components is unchanged).

## What changed

**Core (RSC support)**
- `'use client'` directive added to every component entry file so it survives the build into each `dist` chunk (previously only on the barrel, where Rollup flattened it away and no directive reached `dist/`).
- All 17 compound components now expose **named subpart exports** with dot-matching aliases (e.g. `SelectButton`, `DialogPanel`, `TabsTab`, `ContainerItem`). Dot access (`Select.Button`) can't cross the RSC boundary; named exports are individual client references.
- Drawer subpart files marked `'use client'` (they live in separate modules the bundler would otherwise hoist past the client boundary).
- SSR guards: `Sidebar` initial collapsed state and `getOperatingSystem()` no longer touch `window` during render.

**Storybook docs**
- A "Next.js Usage" doc page for every component (nested under each component), with a TL;DR, Server-Component example, named-export guidance, and an isolated live `<Canvas>` preview.
- A shared **Guides → Using force-ui with Next.js** overview (Server vs Client components, install, CSS import, named-export rule).
- `.storybook/main.ts` adjusted so MDX builds under the library Vite config.

**Changelog**
- `1.8.0` entry added. `package.json` version intentionally left unbumped (to be cut separately).

## Verification
- `npm run build` (tsc + vite) and `build-storybook` both pass.
- Every `dist/components/*/*.{es,cjs}.js` entry chunk leads with `"use client"`.
- Verified end-to-end in a Next.js 15 and Next.js 16.2.9 App Router app: all 17 compound components render in a Server Component with no RSC/SSR errors.

## Notes
- Interactive triggers for Dialog/Drawer/DropdownMenu still require the trigger element to originate in a client component (React can't attach a ref to a Server-Component-created element) — this is an RSC rule, documented on the relevant pages.
