### PR TITLE
[SUR-488] [ForceUI] Add reverse position support for the bordered variant radio-button component

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+Version x.x.x - xth July, 2026
+- Improvement: Atom - Radio Button: Added reverse position support.
+
 Version 1.7.13 - 11th June, 2026
 - Fix: Resolved `patch-package: command not found` install failure when the library is consumed as a git dependency. `patch-package` is now a runtime dependency so the bundled Lexical Shadow DOM patches are applied in consumer projects, which is required for the Editor Input mention menu Shadow DOM fix to work.
 

--- a/src/components/radio-button/radio-button.stories.tsx
+++ b/src/components/radio-button/radio-button.stories.tsx
@@ -157,6 +157,81 @@ RadioWithBorderSmallSize.args = {
 	size: 'sm',
 };
 
+const RadioWithBorderReversePositionTemplate: StoryFn<RadioButtonGroupProps> = (
+	args
+) => {
+	const [ value, setValue ] = useState( args.value || args.defaultValue );
+
+	return (
+		<RadioButton.Group
+			value={ value }
+			columns={ args.columns ?? 3 }
+			onChange={ ( val ) => {
+				setValue( val as string );
+			} }
+			{ ...args }
+		>
+			{ [ 1, 2, 3, 4, 5, 6 ].map( ( num ) => (
+				<RadioButton.Button
+					key={ num }
+					value={ `option${ num }` }
+					label={ {
+						heading: `Option ${ num }`,
+					} }
+					disabled={ args.disabled }
+					borderOn={ true }
+					reversePosition={ true }
+				/>
+			) ) }
+		</RadioButton.Group>
+	);
+};
+
+export const RadioWithBorderReversePosition =
+	RadioWithBorderReversePositionTemplate.bind( {} );
+RadioWithBorderReversePosition.args = {
+	size: 'md',
+};
+
+const SwitchWithBorderReversePositionTemplate: StoryFn<
+	RadioButtonGroupProps
+> = ( args ) => {
+	const [ value, setValue ] = useState<string[]>( [] );
+
+	return (
+		<RadioButton.Group
+			value={ value }
+			columns={ args.columns ?? 2 }
+			multiSelection={ true }
+			onChange={ ( val ) => {
+				setValue( val as string[] );
+			} }
+			{ ...args }
+		>
+			{ [ 1, 2, 3, 4 ].map( ( num ) => (
+				<RadioButton.Button
+					key={ num }
+					value={ `option${ num }` }
+					label={ {
+						heading: `Option ${ num }`,
+						description: `Description ${ num }`,
+					} }
+					disabled={ args.disabled }
+					borderOn={ true }
+					reversePosition={ true }
+					useSwitch={ true }
+				/>
+			) ) }
+		</RadioButton.Group>
+	);
+};
+
+export const SwitchWithBorderReversePosition =
+	SwitchWithBorderReversePositionTemplate.bind( {} );
+SwitchWithBorderReversePosition.args = {
+	size: 'md',
+};
+
 const defaultRadioButtonGroupData = [
 	{
 		id: '1',

--- a/src/components/radio-button/radio-button.tsx
+++ b/src/components/radio-button/radio-button.tsx
@@ -101,7 +101,7 @@ export interface RadioButtonProps extends RadioButtonCommonProps {
 	inlineIcon?: boolean;
 	/** Hides the selection indicator */
 	hideSelection?: boolean;
-	/** Reverses the position of icon and label */
+	/** Places the selection control (radio/switch) on the left and the label on the right. Works with the bordered variant (`borderOn`) */
 	reversePosition?: boolean;
 	/** Adds a border around the button */
 	borderOn?: boolean;
@@ -340,7 +340,6 @@ export const RadioButtonComponent = (
 						'space-y-3': size === 'sm',
 						'space-y-4': size === 'md',
 					},
-					reversePosition && ( useSwitch ? 'ml-10' : 'ml-4' ),
 					inlineIcon && 'flex gap-2',
 					inlineIcon && ! label.description && 'items-center'
 				) }
@@ -358,7 +357,7 @@ export const RadioButtonComponent = (
 				>
 					<p
 						className={ cn(
-							'text-text-primary font-medium m-0',
+							'text-text-primary font-medium m-0 [overflow-wrap:anywhere]',
 							textSizeClassNames[
 								size as keyof typeof textSizeClassNames
 							],
@@ -368,7 +367,7 @@ export const RadioButtonComponent = (
 						{ label.heading }
 					</p>
 					{ label.description && (
-						<p className="text-text-tertiary text-sm font-normal leading-5 m-0">
+						<p className="text-text-tertiary text-sm font-normal leading-5 m-0 [overflow-wrap:anywhere]">
 							{ label.description }
 						</p>
 					) }
@@ -405,6 +404,13 @@ export const RadioButtonComponent = (
 		}
 	};
 
+	// Reserve space on the control side. Default: control on the right (pr-12).
+	// Reversed: control on the left; the switch needs more room than the radio.
+	let controlSpacingClass = 'pr-12';
+	if ( reversePosition ) {
+		controlSpacingClass = useSwitch ? 'pl-16' : 'pl-12';
+	}
+
 	const paddingClasses = {
 		'pl-3.5 pr-2.5 py-2.5': size === 'sm' && ! ( icon && useSwitch ),
 		'p-3': size === 'sm' && ( ( icon && useSwitch ) || ( icon && badgeItem ) ),
@@ -425,7 +431,7 @@ export const RadioButtonComponent = (
 					checkedValue &&
 					'outline-border-interactive',
 				paddingClasses,
-				'pr-12',
+				controlSpacingClass,
 				isDisabled && 'cursor-not-allowed opacity-40',
 				buttonWrapperClasses
 			) }
@@ -457,10 +463,10 @@ export const RadioButtonComponent = (
 			) }
 			<label
 				className={ cn(
-					'absolute mr-0.5 right-3 flex items-center cursor-pointer rounded-full gap-2',
-					reversePosition && 'left-0',
+					'absolute flex items-center cursor-pointer rounded-full gap-2',
+					reversePosition ? 'left-3 ml-0.5' : 'right-3 mr-0.5',
 					isDisabled && 'cursor-not-allowed',
-					inlineIcon && 'mr-3'
+					inlineIcon && ( reversePosition ? 'ml-3' : 'mr-3' )
 				) }
 				onClick={ handleLabelClick }
 			>

--- a/src/theme/default-config.js
+++ b/src/theme/default-config.js
@@ -231,6 +231,7 @@ const defaultTheme = {
 			},
 			borderWidth: {
 				0.5: '0.5px',
+				1.5: '1.5px',
 			},
 		},
 	},


### PR DESCRIPTION
## What

Adds working `reversePosition` support for the bordered (`borderOn`) RadioButton variant: the radio/switch control renders inset on the left edge inside the border with mirrored horizontal padding, label on the right.

Closes brainstormforce/surerank#1905 (SUR-488)

## Changes

- **`radio-button.tsx`**
  - Control wrapper anchored `left-3 ml-0.5` when reversed (previously got both `left-0` and `right-3`, stretching across the card and sitting flush against the border).
  - Card padding mirrors when reversed: `pl-12` (radio) / `pl-16` (switch) replaces the hardcoded `pr-12`; removed the old `ml-4`/`ml-10` label margin hacks.
  - Label heading/description wrap with `overflow-wrap: anywhere` so long unbroken words no longer overflow the card border in narrow containers.
- **`theme/default-config.js`** — added `1.5: '1.5px'` to the `borderWidth` scale. The `!border-1.5` class used by radio and checkbox generated no CSS, so both rendered with the 3px browser-default border; they now render at the intended 1.5px.
- **`radio-button.stories.tsx`** — new `RadioWithBorderReversePosition` and `SwitchWithBorderReversePosition` stories.
- **`changelog.txt`** — entry added.

## Testing

- Vitest Storybook suite: 218/218 pass
- `tsc -b`, ESLint (`./src`), Stylelint: clean
- Vite production build: OK
- Visual verification in Chrome across 9 scenarios: reversed radio md/sm, reversed switch with multi-selection, long heading/description, unbroken 80-char token in a 340px container, default bordered + simple story regressions, radio/checkbox computed border width 1.5px with checked states intact.