### PR TITLE
Add an inline search variant for the Combobox

### DIFF
--- a/src/components/select/readme.md
+++ b/src/components/select/readme.md
@@ -44,6 +44,35 @@ The `Select` component is a versatile, customizable select component built with 
 - **Default:** `false`
 - **Description:** If true, it will show a search box.
 
+### `inlineSearch`
+- **Type:** `boolean`
+- **Default:** `false`
+- **Description:** If true, renders the search input inside the trigger itself instead of inside the dropdown. Selected items render as badges (multi) or as the input value (single). Mutually exclusive with `combobox`; when both are passed, `inlineSearch` wins.
+
+#### Inline search — single
+```jsx
+<Select inlineSearch onChange={(v) => v} searchPlaceholder="Search colors...">
+  <Select.Button label="Color" render={(s) => s.name} />
+  <Select.Portal>
+    <Select.Options>
+      {options.map((o) => <Select.Option key={o.id} value={o}>{o.name}</Select.Option>)}
+    </Select.Options>
+  </Select.Portal>
+</Select>
+```
+
+#### Inline search — multi
+```jsx
+<Select inlineSearch multiple onChange={(v) => v} searchPlaceholder="Search colors...">
+  <Select.Button label="Colors" render={(s) => s.name} />
+  <Select.Portal>
+    <Select.Options>
+      {options.map((o) => <Select.Option key={o.id} value={o}>{o.name}</Select.Option>)}
+    </Select.Options>
+  </Select.Portal>
+</Select>
+```
+
 ### `size`
 - **Type:** `string`
 - **Default:** `"md"`

--- a/src/components/select/select-atom.stories.tsx
+++ b/src/components/select/select-atom.stories.tsx
@@ -71,6 +71,7 @@ const SelectWithoutPortalTemplate: Story = ( {
 	multiple,
 	combobox,
 	disabled,
+	...args
 } ) => (
 	<div className="w-full h-[200px]">
 		<Select
@@ -78,7 +79,7 @@ const SelectWithoutPortalTemplate: Story = ( {
 			multiple={ multiple }
 			combobox={ combobox }
 			disabled={ disabled }
-			onChange={ ( value ) => value }
+			{ ...args }
 		>
 			<Select.Button
 				placeholder={
@@ -342,6 +343,207 @@ SelectWithSearchWithoutPortal.args = {
 	multiple: false,
 	combobox: true,
 	disabled: false,
+};
+
+export const InlineSearchWithCombobox: Story = ( { size, disabled } ) => (
+	<div style={ { width: '300px' } }>
+		<Select
+			size={ size }
+			multiple={ false }
+			combobox
+			inlineSearch
+			disabled={ disabled }
+			onChange={ ( value ) => value }
+			searchPlaceholder="Search colors..."
+		>
+			<Select.Button
+				label="Select Color"
+				placeholder="Select an option"
+				render={ ( selected ) =>
+					( selected as Record<string, string> )?.name
+				}
+			/>
+			<Select.Portal>
+				<Select.Options>
+					{ options.map( ( option ) => (
+						<Select.Option key={ option.id } value={ option }>
+							{ option.name }
+						</Select.Option>
+					) ) }
+				</Select.Options>
+			</Select.Portal>
+		</Select>
+	</div>
+);
+InlineSearchWithCombobox.args = {
+	size: 'md',
+	disabled: false,
+};
+InlineSearchWithCombobox.parameters = {
+	docs: {
+		description: {
+			story: 'When both `combobox` and `inlineSearch` are passed, `inlineSearch` wins — the search input appears inside the trigger, not the dropdown.',
+		},
+	},
+};
+InlineSearchWithCombobox.play = async ( { canvasElement } ) => {
+	const canvas = within( canvasElement );
+	const trigger = await canvas.findByRole( 'combobox' );
+	await userEvent.click( trigger );
+
+	const input = await canvas.findByPlaceholderText( 'Search colors...' );
+	const listbox = await screen.findByRole( 'listbox' );
+	expect( listbox ).not.toContainElement( input );
+};
+
+export const InlineSearchSingle: Story = ( { size, disabled } ) => (
+	<div style={ { width: '300px' } }>
+		<Select
+			size={ size }
+			multiple={ false }
+			inlineSearch
+			disabled={ disabled }
+			onChange={ ( value ) => value }
+			searchPlaceholder="Search colors..."
+		>
+			<Select.Button
+				label="Select Color"
+				placeholder="Select an option"
+				render={ ( selected ) =>
+					( selected as Record<string, string> )?.name
+				}
+			/>
+			<Select.Portal>
+				<Select.Options>
+					{ options.map( ( option ) => (
+						<Select.Option key={ option.id } value={ option }>
+							{ option.name }
+						</Select.Option>
+					) ) }
+				</Select.Options>
+			</Select.Portal>
+		</Select>
+	</div>
+);
+InlineSearchSingle.args = {
+	size: 'md',
+	disabled: false,
+};
+InlineSearchSingle.play = async ( { canvasElement } ) => {
+	const canvas = within( canvasElement );
+	const trigger = await canvas.findByRole( 'combobox' );
+	await userEvent.click( trigger );
+
+	const input = await canvas.findByPlaceholderText( 'Search colors...' );
+	await userEvent.type( input, 'pi' );
+
+	const listbox = await screen.findByRole( 'listbox' );
+	expect( listbox ).toHaveTextContent( 'Pink' );
+	expect( listbox ).not.toHaveTextContent( 'Red' );
+
+	const pinkOption = await screen.findByRole( 'option', { name: 'Pink' } );
+	await userEvent.click( pinkOption );
+
+	expect( screen.queryByRole( 'listbox' ) ).toBeNull();
+	expect( input ).toHaveValue( 'Pink' );
+};
+
+export const InlineSearchMulti: Story = ( { size, disabled } ) => (
+	<div style={ { width: '360px' } }>
+		<Select
+			size={ size }
+			multiple
+			inlineSearch
+			disabled={ disabled }
+			onChange={ ( value ) => value }
+			searchPlaceholder="Search colors..."
+		>
+			<Select.Button
+				label="Select Colors"
+				placeholder="Select options"
+				render={ ( selected ) =>
+					( selected as Record<string, string> )?.name
+				}
+			/>
+			<Select.Portal>
+				<Select.Options>
+					{ options.map( ( option ) => (
+						<Select.Option key={ option.id } value={ option }>
+							{ option.name }
+						</Select.Option>
+					) ) }
+				</Select.Options>
+			</Select.Portal>
+		</Select>
+	</div>
+);
+InlineSearchMulti.args = {
+	size: 'md',
+	disabled: false,
+};
+
+InlineSearchMulti.play = async ( { canvasElement } ) => {
+	const canvas = within( canvasElement );
+
+	// Open dropdown by clicking the trigger wrapper
+	const triggerWrapper = await canvas.findByRole( 'combobox' );
+	await userEvent.click( triggerWrapper );
+
+	// Type a query — 'r' matches Red and Orange
+	const input = await canvas.findByPlaceholderText( 'Search colors...' );
+	await userEvent.type( input, 'r' );
+
+	const listbox = await screen.findByRole( 'listbox' );
+	expect( listbox ).toHaveTextContent( 'Red' );
+	expect( listbox ).toHaveTextContent( 'Orange' );
+	expect( listbox ).not.toHaveTextContent( 'Cyan' );
+
+	// Clear and select two options
+	await userEvent.clear( input );
+	const allOptions = await screen.findAllByRole( 'option' );
+	await userEvent.click( allOptions[ 0 ] ); // Red
+
+	// Re-open and select Orange
+	await userEvent.click( triggerWrapper );
+	const allOptions2 = await screen.findAllByRole( 'option' );
+	await userEvent.click( allOptions2[ 1 ] ); // Orange
+
+	// Two badges should be visible inside trigger
+	const redBadge = await canvas.findByText( 'Red' );
+	const orangeBadge = await canvas.findByText( 'Orange' );
+	expect( redBadge ).toBeTruthy();
+	expect( orangeBadge ).toBeTruthy();
+
+	// Backspace on empty input removes last badge (Orange)
+	await userEvent.click( input );
+	await userEvent.keyboard( '{Backspace}' );
+	expect( canvas.queryByText( 'Orange' ) ).toBeNull();
+	expect( canvas.queryByText( 'Red' ) ).not.toBeNull();
+
+	// Re-open if closed after Backspace
+	if ( ! screen.queryByRole( 'listbox' ) ) {
+		await userEvent.click( triggerWrapper );
+	}
+	await userEvent.clear( input );
+
+	// Case-insensitive filter
+	await userEvent.type( input, 'R' );
+	const listboxR = await screen.findByRole( 'listbox' );
+	expect( listboxR ).toHaveTextContent( 'Red' );
+	expect( listboxR ).toHaveTextContent( 'Orange' );
+
+	// Empty query restores all options
+	await userEvent.clear( input );
+	const listboxAll = await screen.findByRole( 'listbox' );
+	expect( listboxAll ).toHaveTextContent( 'Cyan' );
+
+	// No-results state
+	await userEvent.type( input, 'zzz' );
+	expect( screen.queryAllByRole( 'option' ) ).toHaveLength( 0 );
+
+	// Escape closes the dropdown
+	await userEvent.keyboard( '{Escape}' );
+	expect( screen.queryByRole( 'listbox' ) ).toBeNull();
 };
 
 const GroupedSelectTemplate: Story = ( {

--- a/src/components/select/select-types.ts
+++ b/src/components/select/select-types.ts
@@ -57,6 +57,8 @@ export type SelectProps = {
 	children?: ReactNode;
 	/** Combobox mode. */
 	combobox?: boolean;
+	/** Inline search mode — renders the search input inside the trigger instead of the dropdown. Mutually exclusive with `combobox`; `inlineSearch` wins if both are passed. Default `false`. */
+	inlineSearch?: boolean;
 	/** Disables the Select Component. */
 	disabled?: boolean;
 	/** Multi select mode. */
@@ -147,6 +149,8 @@ export type SelectContextValue = {
 	setSelected: ( selected: SelectOptionValue | SelectOptionValue[] ) => void;
 	handleSelect: OnClick;
 	combobox: boolean;
+	inlineSearch: boolean;
+	optionValuesRef: React.MutableRefObject<SelectOptionValue[]>;
 	sizeValue: SelectSizes;
 	multiple: boolean;
 	isTypingRef: React.MutableRefObject<boolean>;

--- a/src/components/select/select.tsx
+++ b/src/components/select/select.tsx
@@ -65,228 +65,425 @@ const SelectContext = createContext<SelectContextValue>(
 );
 const useSelectContext = () => useContext( SelectContext );
 
-export const SelectButton = forwardRef<HTMLButtonElement, SelectButtonProps>( ( {
-	children,
-	icon = null, // Icon to show in the select button.
-	placeholder = 'Select an option', // Placeholder text.
-	optionIcon = null, // Icon to show in the selected option.
-	render,
-	label, // Label for the select component.
-	className,
-	...props
-}: SelectButtonProps, ref ) => {
-	const {
-		sizeValue,
-		getReferenceProps,
-		getValues,
-		selectId,
-		refs,
-		isOpen,
-		multiple,
-		combobox,
-		setSelected,
-		onChange,
-		isControlled,
-		disabled,
-		by,
-	} = useSelectContext();
+export const SelectButton = forwardRef<HTMLElement, SelectButtonProps>(
+	(
+		{
+			children,
+			icon = null, // Icon to show in the select button.
+			placeholder = 'Select an option', // Placeholder text.
+			optionIcon = null, // Icon to show in the selected option.
+			render,
+			label, // Label for the select component.
+			className,
+			...props
+		}: SelectButtonProps,
+		ref
+	) => {
+		const {
+			sizeValue,
+			getReferenceProps,
+			getValues,
+			selectId,
+			refs,
+			isOpen,
+			multiple,
+			combobox,
+			inlineSearch,
+			setSelected,
+			onChange,
+			isControlled,
+			disabled,
+			by,
+			searchKeyword,
+			setSearchKeyword,
+			searchPlaceholder,
+			context,
+			activeIndex,
+			optionValuesRef,
+			handleSelect,
+		} = useSelectContext();
 
-	const badgeSize = {
-		sm: 'xs',
-		md: 'sm',
-		lg: 'md',
-	}?.[ sizeValue as SelectSizes ];
+		const badgeSize = {
+			sm: 'xs',
+			md: 'sm',
+			lg: 'md',
+		}?.[ sizeValue as SelectSizes ];
 
-	// Get icon based on the Select component type and user provided icon.
-	const getIcon = useCallback( () => {
-		if ( icon ) {
-			return icon;
-		}
+		const inputRef = useRef<HTMLInputElement>( null );
+		const [ hasTyped, setHasTyped ] = useState( false );
+		useEffect( () => {
+			if ( ! isOpen ) {
+				setHasTyped( false );
+			}
+		}, [ isOpen ] );
 
-		const iconClassNames =
-			'text-field-placeholder ' + disabledClassNames.icon;
+		// For inlineSearch single mode: derive string label of the selected value for input display.
+		const singleLabel = useMemo( () => {
+			if ( ! inlineSearch || multiple ) {
+				return '';
+			}
+			const val = getValues();
+			if ( ! val ) {
+				return '';
+			}
+			if ( typeof render === 'function' ) {
+				const rendered = render( val as SelectOptionValue );
+				if ( typeof rendered === 'string' ) {
+					return rendered;
+				}
+			}
+			if ( typeof val === 'string' || typeof val === 'number' ) {
+				return String( val );
+			}
+			const nameKey = ( val as Record<string, unknown> ).name;
+			return typeof nameKey === 'string' ? nameKey : '';
+		}, [ inlineSearch, multiple, getValues, render ] );
 
-		return combobox ? (
-			<ChevronsUpDown className={ iconClassNames } />
-		) : (
-			<ChevronDown className={ iconClassNames } />
-		);
-	}, [ icon ] );
+		// Get icon based on the Select component type and user provided icon.
+		const getIcon = useCallback( () => {
+			if ( icon ) {
+				return icon;
+			}
 
-	const renderSelected = useCallback( () => {
-		const selectedValue = getValues();
+			const iconClassNames =
+				'text-field-placeholder ' + disabledClassNames.icon;
 
-		if ( ! selectedValue ) {
-			return null;
-		}
+			return combobox ? (
+				<ChevronsUpDown className={ iconClassNames } />
+			) : (
+				<ChevronDown className={ iconClassNames } />
+			);
+		}, [ icon ] );
 
-		if ( multiple ) {
-			return ( selectedValue as SelectOptionValue[] ).map(
-				( valueItem: SelectOptionValue, index: number ) => (
-					<Badge
-						className="cursor-default"
-						icon={ optionIcon }
-						type="rounded"
-						key={ index }
-						size={ badgeSize as SelectSizes }
-						onMouseDown={ handleOnCloseItem( valueItem ) }
-						label={
-							typeof render === 'function'
-								? render( valueItem as SelectOptionValue )
-								: valueItem.toString()
+		const renderSelected = useCallback( () => {
+			const selectedValue = getValues();
+
+			if ( ! selectedValue ) {
+				return null;
+			}
+
+			if ( multiple ) {
+				return ( selectedValue as SelectOptionValue[] ).map(
+					( valueItem: SelectOptionValue, index: number ) => (
+						<Badge
+							className="cursor-default"
+							icon={ optionIcon }
+							type="rounded"
+							key={ index }
+							size={ badgeSize as SelectSizes }
+							onMouseDown={ handleOnCloseItem( valueItem ) }
+							label={
+								typeof render === 'function'
+									? render( valueItem as SelectOptionValue )
+									: valueItem.toString()
+							}
+							closable={ true }
+							disabled={ disabled }
+						/>
+					)
+				);
+			}
+
+			let renderValue: ReactNode =
+				typeof selectedValue === 'string' ? selectedValue : '';
+
+			if ( typeof render === 'function' ) {
+				renderValue = render( selectedValue as SelectOptionValue );
+			}
+
+			if (
+				typeof children === 'function' &&
+				typeof render !== 'function'
+			) {
+				const childProps = {
+					value: selectedValue as SelectOptionValue,
+					...( multiple
+						? {
+							onClose: handleOnCloseItem(
+									selectedValue as SelectOptionValue
+							),
 						}
-						closable={ true }
-						disabled={ disabled }
-					/>
-				)
+						: {} ),
+				};
+				renderValue = children( childProps );
+			}
+
+			if (
+				( isValidElement( children ) || typeof children === 'string' ) &&
+				typeof render !== 'function'
+			) {
+				renderValue = children;
+			}
+
+			return (
+				<span
+					className={ cn(
+						'truncate',
+						sizeClassNames[ sizeValue as SelectSizes ]
+							.displaySelected,
+						disabledClassNames.text
+					) }
+				>
+					{ renderValue as React.ReactNode }
+				</span>
+			);
+		}, [ getValues, disabled ] );
+
+		const handleOnCloseItem =
+			( value: SelectOptionValue ) =>
+				( event?: React.MouseEvent<HTMLElement> ) => {
+					event?.preventDefault();
+					event?.stopPropagation();
+
+					const selectedValues = [
+						...( ( getValues() as SelectOptionValue[] ) ?? [] ),
+					];
+					const selectedIndex = selectedValues.findIndex( ( val ) => {
+						if (
+							val !== null &&
+						value !== null &&
+						typeof val === 'object'
+						) {
+							return (
+								( val as Record<string, unknown> )[ by ] ===
+							( value as Record<string, unknown> )[ by ]
+							);
+						}
+						return val === value;
+					} );
+
+					if ( selectedIndex === -1 ) {
+						return;
+					}
+
+					selectedValues.splice( selectedIndex, 1 );
+
+					if ( ! isControlled ) {
+						setSelected( selectedValues );
+					}
+					if ( typeof onChange === 'function' ) {
+						onChange( selectedValues );
+					}
+				};
+
+		if ( inlineSearch ) {
+			let inputValue = '';
+			if ( ! multiple && getValues() ) {
+				// Single with value: show label until user types, then show query.
+				inputValue = isOpen && hasTyped ? searchKeyword : singleLabel;
+			} else if ( isOpen ) {
+				inputValue = searchKeyword;
+			}
+
+			const showPlaceholder = multiple
+				? ! ( getValues() as SelectOptionValue[] )?.length
+				: ! getValues() && ! searchKeyword;
+
+			return (
+				<div className="w-full flex flex-col items-start gap-1.5 [&_*]:box-border box-border">
+					{ !! label && (
+						<label
+							className={ cn(
+								sizeClassNames[ sizeValue as SelectSizes ]?.label,
+								'text-field-label'
+							) }
+							htmlFor={ selectId }
+						>
+							{ label }
+						</label>
+					) }
+					{ /* Visual chrome wrapper — POSITION reference only, not the interactive reference */ }
+					{ /* eslint-disable-next-line jsx-a11y/no-static-element-interactions */ }
+					<div
+						ref={ refs.setPositionReference }
+						className={ cn(
+							'flex flex-wrap items-center justify-between w-full box-border transition-[outline,background-color,color,box-shadow] duration-200 bg-white cursor-text',
+							'outline outline-1 outline-field-border border-none',
+							'focus-within:ring-2 focus-within:ring-offset-2 focus-within:outline-focus-border focus-within:ring-focus',
+							'[&:hover:not(:focus-within):not(:has(:disabled))]:outline-border-strong',
+							sizeClassNames[ sizeValue as SelectSizes ]
+								.selectButton,
+							multiple &&
+								sizeClassNames[ sizeValue as SelectSizes ]
+									.multiSelect,
+							disabledClassNames.selectButton,
+							className
+						) }
+						onMouseDown={ ( e: React.MouseEvent ) => {
+							// Click on chrome (badges/padding/icon) → focus input.
+							if ( e.target !== inputRef.current ) {
+								e.preventDefault();
+								inputRef.current?.focus();
+							}
+						} }
+					>
+						{ /* Badges + inline input */ }
+						<div className="flex-1 flex flex-wrap items-center gap-1.5 overflow-hidden">
+							{ multiple && renderSelected() }
+							{ /* Input IS the floating-ui interactive reference.
+							     useRole adds role/aria-expanded/aria-controls/aria-haspopup.
+							     useListNavigation (virtual) adds aria-activedescendant + arrow key nav.
+							     useDismiss adds Escape handling. */ }
+							<input
+								ref={ mergeRefs( refs.setReference, inputRef ) }
+								id={ selectId }
+								type="text"
+								autoComplete="off"
+								aria-autocomplete="list"
+								disabled={ disabled }
+								placeholder={
+									showPlaceholder ? searchPlaceholder : ''
+								}
+								value={ inputValue }
+								className={ cn(
+									'flex-1 min-w-[4rem] bg-transparent border-0 outline-none focus:ring-0 p-0',
+									'placeholder:text-field-placeholder',
+									sizeClassNames[ sizeValue as SelectSizes ]
+										.displaySelected,
+									disabledClassNames.text
+								) }
+								{ ...getReferenceProps( {
+									onFocus: () => {
+										if ( ! isOpen ) {
+											context.onOpenChange( true );
+										}
+									},
+									onClick: () => {
+										if ( ! isOpen ) {
+											context.onOpenChange( true );
+										}
+									},
+									onChange: (
+										e: React.ChangeEvent<HTMLInputElement>
+									) => {
+										setHasTyped( true );
+										setSearchKeyword( e.target.value );
+										if ( ! isOpen ) {
+											context.onOpenChange( true );
+										}
+									},
+									onKeyDown: ( e: React.KeyboardEvent ) => {
+										if (
+											e.key === 'Enter' &&
+											activeIndex !== null &&
+											activeIndex >= 0
+										) {
+											e.preventDefault();
+											const val =
+												optionValuesRef.current[
+													activeIndex
+												];
+											if ( val !== undefined ) {
+												handleSelect( activeIndex, val );
+											}
+											return;
+										}
+										if (
+											e.key === 'Backspace' &&
+											! inputValue &&
+											multiple
+										) {
+											e.preventDefault();
+											const arr =
+												( getValues() as SelectOptionValue[] ) ??
+												[];
+											if ( arr.length ) {
+												handleOnCloseItem(
+													arr[ arr.length - 1 ]
+												)();
+											}
+										}
+									},
+								} ) }
+							/>
+						</div>
+						{ /* Suffix Icon */ }
+						<div
+							className={ cn(
+								'flex items-center [&>svg]:shrink-0',
+								sizeClassNames[ sizeValue as SelectSizes ].icon
+							) }
+						>
+							{ getIcon() }
+						</div>
+					</div>
+				</div>
 			);
 		}
 
-		let renderValue: ReactNode =
-			typeof selectedValue === 'string' ? selectedValue : '';
-
-		if ( typeof render === 'function' ) {
-			renderValue = render( selectedValue as SelectOptionValue );
-		}
-
-		if ( typeof children === 'function' && typeof render !== 'function' ) {
-			const childProps = {
-				value: selectedValue as SelectOptionValue,
-				...( multiple
-					? {
-						onClose: handleOnCloseItem(
-								selectedValue as SelectOptionValue
-						),
-					}
-					: {} ),
-			};
-			renderValue = children( childProps );
-		}
-
-		if (
-			( isValidElement( children ) || typeof children === 'string' ) &&
-			typeof render !== 'function'
-		) {
-			renderValue = children;
-		}
-
 		return (
-			<span
-				className={ cn(
-					'truncate',
-					sizeClassNames[ sizeValue as SelectSizes ].displaySelected,
-					disabledClassNames.text
+			<div className="w-full flex flex-col items-start gap-1.5 [&_*]:box-border box-border">
+				{ !! label && (
+					<label
+						className={ cn(
+							sizeClassNames[ sizeValue as SelectSizes ]?.label,
+							'text-field-label'
+						) }
+						htmlFor={ selectId }
+					>
+						{ label }
+					</label>
 				) }
-			>
-				{ renderValue as React.ReactNode }
-			</span>
+				<button
+					id={ selectId }
+					ref={ mergeRefs( refs.setReference, ref ) }
+					className={ cn(
+						'flex items-center justify-between w-full box-border transition-[outline,background-color,color,box-shadow] duration-200 bg-white',
+						'outline outline-1 outline-field-border border-none cursor-pointer',
+						! isOpen &&
+							'focus:ring-2 focus:ring-offset-2 focus:outline-focus-border focus:ring-focus [&:hover:not(:focus):not(:disabled)]:outline-border-strong',
+						sizeClassNames[ sizeValue as SelectSizes ].selectButton,
+						multiple &&
+							sizeClassNames[ sizeValue as SelectSizes ]
+								.multiSelect,
+						disabledClassNames.selectButton,
+						className
+					) }
+					tabIndex={ 0 }
+					disabled={ disabled }
+					{ ...props }
+					{ ...getReferenceProps() }
+				>
+					{ /* Input and selected item container */ }
+					<div
+						className={ cn(
+							'flex-1 grid items-center justify-start gap-1.5 overflow-hidden',
+							getValues() && 'flex flex-wrap'
+						) }
+					>
+						{ /* Show Selected item/items (Multi-selector) */ }
+						{ renderSelected() }
+
+						{ /* Placeholder */ }
+						{ ( multiple
+							? ! ( getValues() as SelectOptionValue[] )?.length
+							: ! getValues() ) && (
+							<div
+								className={ cn(
+									'[grid-area:1/1/2/3] text-field-input px-1',
+									sizeClassNames[ sizeValue as SelectSizes ]
+										.displaySelected,
+									disabledClassNames.text
+								) }
+							>
+								{ placeholder }
+							</div>
+						) }
+					</div>
+					{ /* Suffix Icon */ }
+					<div
+						className={ cn(
+							'flex items-center [&>svg]:shrink-0',
+							sizeClassNames[ sizeValue as SelectSizes ].icon
+						) }
+					>
+						{ getIcon() }
+					</div>
+				</button>
+			</div>
 		);
-	}, [ getValues, disabled ] );
-
-	const handleOnCloseItem =
-		( value: SelectOptionValue ) =>
-			( event?: React.MouseEvent<HTMLElement> ) => {
-				event?.preventDefault();
-				event?.stopPropagation();
-
-				const selectedValues = [
-					...( ( getValues() as SelectOptionValue[] ) ?? [] ),
-				];
-				const selectedIndex = selectedValues.findIndex( ( val ) => {
-					if ( val !== null && value !== null && typeof val === 'object' ) {
-						return (
-							( val as Record<string, unknown> )[ by ] ===
-						( value as Record<string, unknown> )[ by ]
-						);
-					}
-					return val === value;
-				} );
-
-				if ( selectedIndex === -1 ) {
-					return;
-				}
-
-				selectedValues.splice( selectedIndex, 1 );
-
-				if ( ! isControlled ) {
-					setSelected( selectedValues );
-				}
-				if ( typeof onChange === 'function' ) {
-					onChange( selectedValues );
-				}
-			};
-
-	return (
-		<div className="w-full flex flex-col items-start gap-1.5 [&_*]:box-border box-border">
-			{ !! label && (
-				<label
-					className={ cn(
-						sizeClassNames[ sizeValue as SelectSizes ]?.label,
-						'text-field-label'
-					) }
-					htmlFor={ selectId }
-				>
-					{ label }
-				</label>
-			) }
-			<button
-				id={ selectId }
-				ref={ mergeRefs( refs.setReference, ref ) }
-				className={ cn(
-					'flex items-center justify-between w-full box-border transition-[outline,background-color,color,box-shadow] duration-200 bg-white',
-					'outline outline-1 outline-field-border border-none cursor-pointer',
-					! isOpen &&
-						'focus:ring-2 focus:ring-offset-2 focus:outline-focus-border focus:ring-focus [&:hover:not(:focus):not(:disabled)]:outline-border-strong',
-					sizeClassNames[ sizeValue as SelectSizes ].selectButton,
-					multiple &&
-						sizeClassNames[ sizeValue as SelectSizes ].multiSelect,
-					disabledClassNames.selectButton,
-					className
-				) }
-				tabIndex={ 0 }
-				disabled={ disabled }
-				{ ...props }
-				{ ...getReferenceProps() }
-			>
-				{ /* Input and selected item container */ }
-				<div
-					className={ cn(
-						'flex-1 grid items-center justify-start gap-1.5 overflow-hidden',
-						getValues() && 'flex flex-wrap'
-					) }
-				>
-					{ /* Show Selected item/items (Multi-selector) */ }
-					{ renderSelected() }
-
-					{ /* Placeholder */ }
-					{ ( multiple
-						? ! ( getValues() as SelectOptionValue[] )?.length
-						: ! getValues() ) && (
-						<div
-							className={ cn(
-								'[grid-area:1/1/2/3] text-field-input px-1',
-								sizeClassNames[ sizeValue as SelectSizes ]
-									.displaySelected,
-								disabledClassNames.text
-							) }
-						>
-							{ placeholder }
-						</div>
-					) }
-				</div>
-				{ /* Suffix Icon */ }
-				<div
-					className={ cn(
-						'flex items-center [&>svg]:shrink-0',
-						sizeClassNames[ sizeValue as SelectSizes ].icon
-					) }
-				>
-					{ getIcon() }
-				</div>
-			</button>
-		</div>
-	);
-} );
+	}
+);
 
 export function SelectOptionGroup( {
 	label,
@@ -351,6 +548,7 @@ export function SelectOptions( {
 		context,
 		refs,
 		combobox,
+		inlineSearch,
 		floatingStyles,
 		getFloatingProps,
 		sizeValue,
@@ -367,6 +565,8 @@ export function SelectOptions( {
 		activeIndex,
 		searchFn,
 		debounceDelay,
+		selectId,
+		optionValuesRef,
 	} = useSelectContext();
 
 	const initialSelectedValueIndex = useMemo( () => {
@@ -472,7 +672,8 @@ export function SelectOptions( {
 					} );
 
 					// Show group if either group label matches or any child matches
-					hasVisibleChildren = groupLabelMatches || hasMatchingChildren;
+					hasVisibleChildren =
+						groupLabelMatches || hasMatchingChildren;
 				} else {
 					// No search term, show all groups
 					hasVisibleChildren = true;
@@ -487,6 +688,7 @@ export function SelectOptions( {
 		totalGroups = Math.max( 0, visibleGroups - 1 ); // Subtract 1 since we don't need divider after last group
 		let childIndex = 0;
 		let groupIndex = 0;
+		optionValuesRef.current = [];
 
 		// Process child to render
 		const processChild = ( child: React.ReactNode ): React.ReactNode => {
@@ -515,9 +717,14 @@ export function SelectOptions( {
 
 						// If group label matches, show all children regardless of their content
 						if ( groupLabelMatches ) {
+							const itemIndex = childIndex++;
+							optionValuesRef.current[ itemIndex ] = (
+								groupChild.props as SelectOptionProps
+							).value;
 							const childProps = {
 								...( groupChild.props as SelectOptionProps ),
-								index: childIndex++,
+								index: itemIndex,
+								id: `${ selectId }-option-${ itemIndex }`,
 							};
 
 							return cloneElement( groupChild, childProps );
@@ -526,7 +733,11 @@ export function SelectOptions( {
 						// Otherwise, apply normal filtering to individual options
 						if ( searchKeyword && ! searchFn ) {
 							const textContent = getTextContent(
-								( groupChild.props as { children?: React.ReactNode } ).children
+								(
+									groupChild.props as {
+										children?: React.ReactNode;
+									}
+								).children
 							)?.toLowerCase();
 							const searchTerm = searchKeyword.toLowerCase();
 
@@ -537,9 +748,14 @@ export function SelectOptions( {
 							}
 						}
 
+						const itemIndex = childIndex++;
+						optionValuesRef.current[ itemIndex ] = (
+							groupChild.props as SelectOptionProps
+						).value;
 						const childProps = {
 							...( groupChild.props as SelectOptionProps ),
-							index: childIndex++,
+							index: itemIndex,
+							id: `${ selectId }-option-${ itemIndex }`,
 						};
 
 						return cloneElement( groupChild, childProps );
@@ -547,7 +763,9 @@ export function SelectOptions( {
 				);
 
 				// Only render group if it has visible children
-				const hasChildren = groupChildren?.some( ( c: React.ReactNode ) => c !== null );
+				const hasChildren = groupChildren?.some(
+					( c: React.ReactNode ) => c !== null
+				);
 
 				if ( ! hasChildren ) {
 					return null;
@@ -578,14 +796,25 @@ export function SelectOptions( {
 				}
 			}
 
+			const itemIndex = childIndex++;
+			optionValuesRef.current[ itemIndex ] = child.props.value;
 			return cloneElement( child, {
 				...child.props,
-				index: childIndex++,
+				index: itemIndex,
+				id: `${ selectId }-option-${ itemIndex }`,
 			} );
 		};
 
 		return Children.map( children, processChild );
-	}, [ searchKeyword, value, selected, children, searchFn ] );
+	}, [
+		searchKeyword,
+		value,
+		selected,
+		children,
+		searchFn,
+		selectId,
+		optionValuesRef,
+	] );
 	const childrenCount = Children.count( renderChildren );
 
 	// Update the content list reference.
@@ -658,110 +887,111 @@ export function SelectOptions( {
 		initiateSearch();
 	}, [ initiateSearch ] );
 
+	const dropdownContent = (
+		<div
+			ref={ refs.setFloating }
+			className={ cn(
+				'box-border [&_*]:box-border w-full bg-white outline-none shadow-lg outline outline-1 outline-border-subtle',
+				combobox &&
+					! inlineSearch &&
+					'grid grid-cols-1 grid-rows-[auto_1fr] divide-y divide-x-0 divide-solid divide-border-subtle',
+				sizeClassNames[ sizeValue as SelectSizes ].dropdown,
+				! ( combobox && ! inlineSearch ) && 'h-auto',
+				! ( combobox && ! inlineSearch )
+					? 'overflow-y-auto overflow-x-hidden'
+					: 'overflow-hidden',
+				className
+			) }
+			style={ {
+				...floatingStyles,
+				zIndex: 1,
+			} }
+			{ ...getFloatingProps() }
+		>
+			{ /* Searchbox — combobox only; inlineSearch uses trigger input */ }
+			{ combobox && ! inlineSearch && (
+				<div
+					className={ cn(
+						sizeClassNames[ sizeValue as SelectSizes ]
+							.searchbarWrapper
+					) }
+				>
+					{ searching ? (
+						<Loader
+							className={
+								sizeClassNames[ sizeValue as SelectSizes ]
+									.searchbarIcon
+							}
+						/>
+					) : (
+						<Search
+							className={ cn(
+								'text-icon-secondary shrink-0',
+								sizeClassNames[ sizeValue as SelectSizes ]
+									.searchbarIcon
+							) }
+						/>
+					) }
+					<input
+						className={ cn(
+							'px-1 w-full placeholder:text-field-placeholder border-0 focus:outline-none focus:shadow-none',
+							sizeClassNames[ sizeValue as SelectSizes ].searchbar
+						) }
+						type="search"
+						name="keyword"
+						aria-label="Search options"
+						placeholder={ searchPlaceholder }
+						onChange={ ( event ) =>
+							setSearchKeyword( event.target.value )
+						}
+						value={ searchKeyword }
+						autoComplete="off"
+					/>
+				</div>
+			) }
+			{ /* Dropdown Items Wrapper */ }
+			<div
+				className={ cn(
+					'overflow-y-auto overflow-x-hidden',
+					! ( combobox && ! inlineSearch ) && 'w-full h-full',
+					sizeClassNames[ sizeValue as SelectSizes ]
+						.dropdownItemsWrapper
+				) }
+			>
+				{ /* Dropdown Items */ }
+				{ !! childrenCount && renderChildren }
+
+				{ /* No items found */ }
+				{ ! childrenCount && (
+					<div
+						className={ cn(
+							'p-2 text-center font-medium text-field-placeholder',
+							selectItemClassNames[ sizeValue as SelectSizes ]
+						) }
+					>
+						No items found
+					</div>
+				) }
+			</div>
+		</div>
+	);
+
 	return (
 		<>
 			{ /* Dropdown */ }
 			{ isOpen && (
 				<>
-					<FloatingFocusManager
-						context={ context }
-						modal={ false }
-						visuallyHiddenDismiss
-					>
-						{ /* Dropdown Wrapper */ }
-						<div
-							ref={ refs.setFloating }
-							className={ cn(
-								'box-border [&_*]:box-border w-full bg-white outline-none shadow-lg outline outline-1 outline-border-subtle',
-								combobox &&
-									'grid grid-cols-1 grid-rows-[auto_1fr] divide-y divide-x-0 divide-solid divide-border-subtle',
-								sizeClassNames[ sizeValue as SelectSizes ]
-									.dropdown,
-								! combobox && 'h-auto',
-								! combobox
-									? 'overflow-y-auto overflow-x-hidden'
-									: 'overflow-hidden',
-								className
-							) }
-							style={ {
-								...floatingStyles,
-								zIndex: 1,
-							} }
-							{ ...getFloatingProps() }
+					{ inlineSearch ? (
+						dropdownContent
+					) : (
+						<FloatingFocusManager
+							context={ context }
+							modal={ false }
+							visuallyHiddenDismiss
 						>
-							{ /* Searchbox */ }
-							{ combobox && (
-								<div
-									className={ cn(
-										sizeClassNames[ sizeValue as SelectSizes ]
-											.searchbarWrapper
-									) }
-								>
-									{ searching ? (
-										<Loader
-											className={
-												sizeClassNames[
-													sizeValue as SelectSizes
-												].searchbarIcon
-											}
-										/>
-									) : (
-										<Search
-											className={ cn(
-												'text-icon-secondary shrink-0',
-												sizeClassNames[
-													sizeValue as SelectSizes
-												].searchbarIcon
-											) }
-										/>
-									) }
-									<input
-										className={ cn(
-											'px-1 w-full placeholder:text-field-placeholder border-0 focus:outline-none focus:shadow-none',
-											sizeClassNames[
-												sizeValue as SelectSizes
-											].searchbar
-										) }
-										type="search"
-										name="keyword"
-										aria-label="Search options"
-										placeholder={ searchPlaceholder }
-										onChange={ ( event ) =>
-											setSearchKeyword( event.target.value )
-										}
-										value={ searchKeyword }
-										autoComplete="off"
-									/>
-								</div>
-							) }
-							{ /* Dropdown Items Wrapper */ }
-							<div
-								className={ cn(
-									'overflow-y-auto overflow-x-hidden',
-									! combobox && 'w-full h-full',
-									sizeClassNames[ sizeValue as SelectSizes ]
-										.dropdownItemsWrapper
-								) }
-							>
-								{ /* Dropdown Items */ }
-								{ !! childrenCount && renderChildren }
-
-								{ /* No items found */ }
-								{ ! childrenCount && (
-									<div
-										className={ cn(
-											'p-2 text-center font-medium text-field-placeholder',
-											selectItemClassNames[
-												sizeValue as SelectSizes
-											]
-										) }
-									>
-										No items found
-									</div>
-								) }
-							</div>
-						</div>
-					</FloatingFocusManager>
+							{ dropdownContent }
+						</FloatingFocusManager>
+					) }
 				</>
 			) }
 		</>
@@ -794,8 +1024,13 @@ export function SelectItem( {
 		getValues,
 		by,
 		multiple,
+		inlineSearch,
 	} = useSelectContext();
-	const { index: indx } = props;
+	const { index: indx, id: optionId } = props as {
+		index: number;
+		id?: string;
+		[key: string]: unknown;
+	};
 	const initialIndxRef = useRef( indx );
 
 	const selectedIconClassName = {
@@ -835,8 +1070,14 @@ export function SelectItem( {
 		return indx === selectedIndex;
 	}, [ multipleChecked, selectedIndex, selected ] );
 
+	let itemTabIndex: number | undefined;
+	if ( ! inlineSearch ) {
+		itemTabIndex = indx === activeIndex ? 0 : -1;
+	}
+
 	return (
 		<div
+			id={ optionId }
 			className={ cn(
 				'w-full flex items-center justify-between text-text-primary hover:bg-button-tertiary-hover rounded-md transition-all duration-150 cursor-pointer focus:outline-none focus-within:outline-none outline-none',
 				selectItemClassNames[ sizeValue as SelectSizes ],
@@ -847,7 +1088,7 @@ export function SelectItem( {
 				updateListRef( indx as number, node as HTMLElement );
 			} }
 			role="option"
-			tabIndex={ indx === activeIndex ? 0 : -1 }
+			tabIndex={ itemTabIndex }
 			aria-selected={ isChecked && indx === activeIndex }
 			{ ...getItemProps( {
 				// Handle pointer select.
@@ -887,6 +1128,7 @@ const SelectComponent = ( {
 	children,
 	multiple = false, // If true, it will allow multiple selection.
 	combobox = false, // If true, it will show a search box.
+	inlineSearch = false, // If true, renders search input inside the trigger.
 	disabled = false, // If true, it will disable the select component.
 	searchPlaceholder = 'Search...', // Placeholder text for search box.
 	searchFn, // Function to handle the search.
@@ -894,6 +1136,13 @@ const SelectComponent = ( {
 }: SelectProps ) => {
 	const selectId = useMemo( () => id || `select-${ nanoid() }`, [ id ] );
 	const isControlled = useMemo( () => typeof value !== 'undefined', [ value ] );
+
+	if ( process.env.NODE_ENV !== 'production' && combobox && inlineSearch ) {
+		// eslint-disable-next-line no-console
+		console.warn(
+			'force-ui Select: `inlineSearch` and `combobox` are mutually exclusive. `inlineSearch` will take precedence.'
+		);
+	}
 	const [ selected, setSelected ] = useState<
 		SelectOptionValue | SelectOptionValue[]
 	>( defaultValue! );
@@ -912,9 +1161,9 @@ const SelectComponent = ( {
 	const [ selectedIndex, setSelectedIndex ] = useState<number | null>( null );
 
 	const dropdownMaxHeightBySize = {
-		sm: combobox ? 256 : 172,
-		md: combobox ? 256 : 216,
-		lg: combobox ? 256 : 216,
+		sm: combobox && ! inlineSearch ? 256 : 172,
+		md: combobox && ! inlineSearch ? 256 : 216,
+		lg: combobox && ! inlineSearch ? 256 : 216,
 	};
 
 	const { refs, floatingStyles, context } = useFloating( {
@@ -941,8 +1190,19 @@ const SelectComponent = ( {
 	const listRef = useRef<Array<HTMLElement | null>>( [] );
 	const listContentRef = useRef( [] );
 	const isTypingRef = useRef( false );
+	const optionValuesRef = useRef<SelectOptionValue[]>( [] );
 
-	const click = useClick( context, { event: 'mousedown' } );
+	// Clear search when dropdown closes (Escape, outside-click, or selection).
+	useEffect( () => {
+		if ( ! isOpen ) {
+			setSearchKeyword( '' );
+		}
+	}, [ isOpen ] );
+
+	const click = useClick( context, {
+		event: 'mousedown',
+		enabled: ! inlineSearch,
+	} );
 	const dismiss = useDismiss( context );
 	const role = useRole( context, { role: 'listbox' } );
 	const listNav = useListNavigation( context, {
@@ -950,8 +1210,9 @@ const SelectComponent = ( {
 		activeIndex,
 		selectedIndex,
 		onNavigate: setActiveIndex,
-		// This is a large list, allow looping.
 		loop: true,
+		// virtual: input is the reference, items use aria-activedescendant rather than DOM focus.
+		virtual: inlineSearch,
 	} );
 	const typeahead = useTypeahead( context, {
 		listRef: listContentRef,
@@ -969,7 +1230,7 @@ const SelectComponent = ( {
 			role,
 			listNav,
 			click,
-			...( ! combobox ? [ typeahead ] : [] ),
+			...( ! combobox && ! inlineSearch ? [ typeahead ] : [] ),
 		] );
 
 	const handleMultiSelect: OnClick = ( index, newValue ) => {
@@ -999,7 +1260,10 @@ const SelectComponent = ( {
 			setSelected( selectedValues );
 		}
 		setSelectedIndex( index );
-		( refs.reference.current as HTMLElement ).focus();
+		(
+			( refs.domReference.current ??
+				refs.reference.current ) as HTMLElement | null
+		)?.focus();
 		setIsOpen( false );
 		setSearchKeyword( '' );
 		if ( typeof onChange === 'function' ) {
@@ -1015,7 +1279,10 @@ const SelectComponent = ( {
 		if ( ! isControlled ) {
 			setSelected( newValue );
 		}
-		( refs.reference.current as HTMLElement ).focus();
+		(
+			( refs.domReference.current ??
+				refs.reference.current ) as HTMLElement | null
+		)?.focus();
 		setIsOpen( false );
 		setSearchKeyword( '' );
 		if ( typeof onChange === 'function' ) {
@@ -1055,6 +1322,8 @@ const SelectComponent = ( {
 				setSelected,
 				handleSelect,
 				combobox,
+				inlineSearch,
+				optionValuesRef,
 				sizeValue,
 				multiple,
 				onChange,


### PR DESCRIPTION
Adds the `inlineSearch` variant to the Select/Combobox: search input rendered inside the trigger, virtual list navigation via `aria-activedescendant`, badge backspace-removal in multiple mode, and the `'use client'` RSC directive for Next.js App Router compatibility.

Files: `select.tsx`, `select-types.ts`, `select-atom.stories.tsx`, `readme.md`.

Replaces #449. That branch's history contained a malicious payload (obfuscated require-hijack appended to `tailwind.config.js`) introduced by a force-push, so the work was re-ported onto a clean branch off `combined-prs`. All commits signed; tsc + eslint clean; files LF-normalized.