### PR TITLE
[SUR-488] Fix borderless reverse-position radio/switch alignment

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,8 +1,8 @@
 Version 1.8.0 - 17th July, 2026
 - New: Atom - File Picker: Added a standalone file upload component that displays the selected file name and supports a controlled value and an optional clear action.
 - New: Atom - Select: Added `inlineSearch` prop that renders the search input inside the trigger instead of the dropdown. Selected items render as badges (multiple) or as the input value (single). Mutually exclusive with `combobox`; `inlineSearch` wins when both are passed.
-- Improvement: Atom - Radio Button: Added reverse position support.
 - New: Added Next.js React Server Components support. Every component now ships the `"use client"` directive in its build output, and compound components additionally expose named subpart exports (e.g. `SelectButton`, `DialogPanel`) so they can be rendered directly inside Server Components.
+- Improvement: Atom - Radio Button: Added reverse position support.
 
 Version 1.7.13 - 11th June, 2026
 - Fix: Resolved `patch-package: command not found` install failure when the library is consumed as a git dependency. `patch-package` is now a runtime dependency so the bundled Lexical Shadow DOM patches are applied in consumer projects, which is required for the Editor Input mention menu Shadow DOM fix to work.

--- a/src/components/radio-button/radio-button.tsx
+++ b/src/components/radio-button/radio-button.tsx
@@ -341,6 +341,11 @@ export const RadioButtonComponent = (
 						'space-y-3': size === 'sm',
 						'space-y-4': size === 'md',
 					},
+					// Borderless reverse layout keeps the control flush left, so
+					// offset the content by the control width (legacy behavior).
+					reversePosition &&
+						! borderOn &&
+						( useSwitch ? 'ml-10' : 'ml-4' ),
 					inlineIcon && 'flex gap-2',
 					inlineIcon && ! label.description && 'items-center'
 				) }
@@ -375,7 +380,7 @@ export const RadioButtonComponent = (
 				</div>
 			</div>
 		);
-	}, [ label ] );
+	}, [ label, reversePosition, borderOn, useSwitch ] );
 
 	if ( providerValue.style === 'tile' ) {
 		return (
@@ -406,10 +411,19 @@ export const RadioButtonComponent = (
 	};
 
 	// Reserve space on the control side. Default: control on the right (pr-12).
-	// Reversed: control on the left; the switch needs more room than the radio.
+	// Bordered + reversed: control on the left, inset from the border; the
+	// switch needs more room than the radio. Borderless reverse keeps the
+	// legacy flush-left layout (content offset handled in renderLabel).
 	let controlSpacingClass = 'pr-12';
-	if ( reversePosition ) {
+	if ( reversePosition && borderOn ) {
 		controlSpacingClass = useSwitch ? 'pl-16' : 'pl-12';
+	}
+
+	// Control anchor: right by default; reversed sits left — inset inside a
+	// border, flush against the edge without one (legacy behavior).
+	let controlPositionClass = 'right-3 mr-0.5';
+	if ( reversePosition ) {
+		controlPositionClass = borderOn ? 'left-3 ml-0.5' : 'left-0';
 	}
 
 	const paddingClasses = {
@@ -465,9 +479,10 @@ export const RadioButtonComponent = (
 			<label
 				className={ cn(
 					'absolute flex items-center cursor-pointer rounded-full gap-2',
-					reversePosition ? 'left-3 ml-0.5' : 'right-3 mr-0.5',
+					controlPositionClass,
 					isDisabled && 'cursor-not-allowed',
-					inlineIcon && ( reversePosition ? 'ml-3' : 'mr-3' )
+					inlineIcon &&
+						( reversePosition && borderOn ? 'ml-3' : 'mr-3' )
 				) }
 				onClick={ handleLabelClick }
 			>


### PR DESCRIPTION
## Summary

PR #471 added reverse-position support for the **bordered** radio-button variant, but the new geometry applied to every `reversePosition` usage:

- the control moved from flush `left-0` to `left-3 ml-0.5` (~14px inset)
- the wrapper gained `pl-16`/`pl-12` padding

For **borderless** reversed usage — e.g. the SureEmails onboarding template's `useSwitch + reversePosition` opt-in — this shifted the switch right and misaligned it with surrounding form fields.

## Fix

Scope the inset geometry to `borderOn`. Without a border, the legacy layout is restored: control flush at `left-0`, content offset via `ml-10` (switch) / `ml-4` (radio). The nested ternary is extracted into a `controlPositionClass` variable to satisfy `no-nested-ternary`.

| Case | Before this PR | After |
|---|---|---|
| `reversePosition` + `borderOn` | control inset 14px (intended) | unchanged |
| `reversePosition` borderless | control inset 14px (regression) | flush left (pre-#471 layout) |
| default (not reversed) | unchanged | unchanged |

## Testing

- `Templates/Onboarding/Spam` story: switch left edge aligns with the field above again
- `Atoms/RadioButton` bordered reverse-position stories (radio + switch): inset intact
- eslint, `tsc -b`, and radio-button storybook interaction tests pass