### PR TITLE
#490 - Select: multiple mode closes the dropdown after every selection

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,5 @@
-Version 1.8.1 - 3rd August, 2026
+Version 1.8.1 - 4th August, 2026
+- Fix: Atom - Select: In `multiple` mode the dropdown now stays open while selecting or deselecting options, closing only on Escape or outside click.
 - New: Organism - Editor Input: Added optional `triggerRegex` prop that overrides the built-in mention-suggestion matcher, so consumers can allow the trigger without a leading blank space (e.g. directly after a double quote inside JSON string values). The custom regex must expose the same capture groups as the built-in matcher: 1 = leading boundary, 2 = replaceable string (trigger + query), 3 = query string used to filter options. When omitted, the existing trigger-based matcher is used unchanged.
 
 Version 1.8.0 - 17th July, 2026

--- a/src/components/select/select-atom.stories.tsx
+++ b/src/components/select/select-atom.stories.tsx
@@ -554,6 +554,81 @@ InlineSearchMulti.play = async ( { canvasElement } ) => {
 	expect( screen.queryByRole( 'listbox' ) ).toBeNull();
 };
 
+// Toggling `multiple` at runtime while a selection already exists.
+export const ToggleMultipleAtRuntime: Story = ( { size, disabled } ) => {
+	const [ multiple, setMultiple ] = useState( false );
+	return (
+		<div style={ { width: '300px' } }>
+			<button type="button" onClick={ () => setMultiple( ( v ) => ! v ) }>
+				{ multiple ? 'Disable multiple' : 'Enable multiple' }
+			</button>
+			<Select
+				size={ size }
+				multiple={ multiple }
+				disabled={ disabled }
+				onChange={ ( value ) => value }
+			>
+				<Select.Button
+					label="Select a Color"
+					placeholder="Select an option"
+					render={ ( selected ) =>
+						( selected as Record<string, string> )?.name
+					}
+				/>
+				<Select.Portal>
+					<Select.Options>
+						{ options.map( ( option ) => (
+							<Select.Option key={ option.id } value={ option }>
+								{ option.name }
+							</Select.Option>
+						) ) }
+					</Select.Options>
+				</Select.Portal>
+			</Select>
+		</div>
+	);
+};
+ToggleMultipleAtRuntime.args = {
+	size: 'md',
+	disabled: false,
+};
+ToggleMultipleAtRuntime.parameters = {
+	docs: {
+		description: {
+			story: 'The `multiple` prop can be flipped after a selection exists. The existing single value is treated as a one-item list instead of throwing.',
+		},
+	},
+};
+ToggleMultipleAtRuntime.play = async ( { canvasElement } ) => {
+	const canvas = within( canvasElement );
+
+	// Single mode: pick Red.
+	const trigger = await canvas.findByRole( 'combobox' );
+	await userEvent.click( trigger );
+	await userEvent.click( await screen.findByRole( 'option', { name: 'Red' } ) );
+	expect( trigger ).toHaveTextContent( 'Red' );
+
+	// Flip to multiple mode — previous single value survives as a badge.
+	await userEvent.click(
+		await canvas.findByRole( 'button', { name: 'Enable multiple' } )
+	);
+	expect( trigger ).toHaveTextContent( 'Red' );
+
+	// Selecting another option must not crash and must append.
+	await userEvent.click( trigger );
+	await userEvent.click(
+		await screen.findByRole( 'option', { name: 'Orange' } )
+	);
+	expect( trigger ).toHaveTextContent( /Red.*Orange/ );
+
+	// Flip back to single mode — first value is shown, still no crash.
+	await userEvent.keyboard( '{Escape}' );
+	await userEvent.click(
+		await canvas.findByRole( 'button', { name: 'Disable multiple' } )
+	);
+	expect( trigger ).toHaveTextContent( 'Red' );
+};
+
 const GroupedSelectTemplate: Story = ( {
 	size,
 	multiple,

--- a/src/components/select/select-atom.stories.tsx
+++ b/src/components/select/select-atom.stories.tsx
@@ -248,17 +248,25 @@ MultiSelect.play = async ( { canvasElement } ) => {
 	const listBox = await screen.findByRole( 'listbox' );
 	expect( listBox ).toHaveTextContent( 'Red' );
 
-	// Click on the first option
+	// Select two options — the dropdown stays open in multiple mode
 	const allOptions = await screen.findAllByRole( 'option' );
-	await userEvent.click( allOptions[ 0 ] );
-
-	// Check if the listbox contains the option 'Orange'
-	await userEvent.click( selectButton );
-	const allOptions2 = await screen.findAllByRole( 'option' );
-	await userEvent.click( allOptions2[ 1 ] );
+	await userEvent.click( allOptions[ 0 ] ); // Red
+	expect( screen.queryByRole( 'listbox' ) ).not.toBeNull();
+	await userEvent.click( allOptions[ 1 ] ); // Orange
+	expect( screen.queryByRole( 'listbox' ) ).not.toBeNull();
 
 	// Check if the button text is updated
 	expect( selectButton ).toHaveTextContent( /Red.*Orange/ );
+
+	// Clicking an already-selected option deselects it without closing
+	await userEvent.click( allOptions[ 1 ] ); // Orange (toggle off)
+	expect( screen.queryByRole( 'listbox' ) ).not.toBeNull();
+	expect( selectButton ).toHaveTextContent( 'Red' );
+	expect( selectButton ).not.toHaveTextContent( 'Orange' );
+
+	// Escape still closes the dropdown
+	await userEvent.keyboard( '{Escape}' );
+	expect( screen.queryByRole( 'listbox' ) ).toBeNull();
 };
 
 export const MultiSelectWithoutPortal = SelectWithoutPortalTemplate.bind( {} );
@@ -498,15 +506,15 @@ InlineSearchMulti.play = async ( { canvasElement } ) => {
 	expect( listbox ).toHaveTextContent( 'Orange' );
 	expect( listbox ).not.toHaveTextContent( 'Cyan' );
 
-	// Clear and select two options
+	// Clear and select two options — dropdown stays open in multiple mode
 	await userEvent.clear( input );
 	const allOptions = await screen.findAllByRole( 'option' );
 	await userEvent.click( allOptions[ 0 ] ); // Red
+	expect( screen.queryByRole( 'listbox' ) ).not.toBeNull();
 
-	// Re-open and select Orange
-	await userEvent.click( triggerWrapper );
 	const allOptions2 = await screen.findAllByRole( 'option' );
 	await userEvent.click( allOptions2[ 1 ] ); // Orange
+	expect( screen.queryByRole( 'listbox' ) ).not.toBeNull();
 
 	// Two badges should be visible inside trigger
 	const redBadge = await canvas.findByText( 'Red' );

--- a/src/components/select/select.tsx
+++ b/src/components/select/select.tsx
@@ -1251,20 +1251,19 @@ const SelectComponent = ( {
 			return selectedValue === newValue;
 		} );
 
+		// Toggle: deselect if already selected, otherwise select. The
+		// dropdown stays open so multiple options can be picked in one go;
+		// Escape and outside click (useDismiss) still close it.
 		if ( valueIndex !== -1 ) {
-			return;
+			selectedValues.splice( valueIndex, 1 );
+		} else {
+			selectedValues.push( newValue );
+			setSelectedIndex( index );
 		}
-		selectedValues.push( newValue );
 
 		if ( ! isControlled ) {
 			setSelected( selectedValues );
 		}
-		setSelectedIndex( index );
-		(
-			( refs.domReference.current ??
-				refs.reference.current ) as HTMLElement | null
-		)?.focus();
-		setIsOpen( false );
 		setSearchKeyword( '' );
 		if ( typeof onChange === 'function' ) {
 			onChange( selectedValues );

--- a/src/components/select/select.tsx
+++ b/src/components/select/select.tsx
@@ -56,7 +56,7 @@ import type {
 	SelectSizes,
 	SelectOptionGroupProps,
 } from './select-types';
-import { getTextContent } from './utils';
+import { getTextContent, toValuesArray } from './utils';
 import { useDebouncedCallback } from '@/utilities/hooks';
 
 // Context to manage the state of the select component.
@@ -156,14 +156,14 @@ export const SelectButton = forwardRef<HTMLElement, SelectButtonProps>(
 		}, [ icon ] );
 
 		const renderSelected = useCallback( () => {
-			const selectedValue = getValues();
+			const currentValue = getValues();
 
-			if ( ! selectedValue ) {
+			if ( ! currentValue ) {
 				return null;
 			}
 
 			if ( multiple ) {
-				return ( selectedValue as SelectOptionValue[] ).map(
+				return toValuesArray( currentValue ).map(
 					( valueItem: SelectOptionValue, index: number ) => (
 						<Badge
 							className="cursor-default"
@@ -184,6 +184,15 @@ export const SelectButton = forwardRef<HTMLElement, SelectButtonProps>(
 				);
 			}
 
+			// Single mode can still hold an array when `multiple` is toggled at
+			// runtime — fall back to the first entry so render()/children get a
+			// single value. An empty array is passed through untouched to keep
+			// the value render()/children already received.
+			const selectedValue =
+				Array.isArray( currentValue ) && currentValue.length
+					? currentValue[ 0 ]
+					: currentValue;
+
 			let renderValue: ReactNode =
 				typeof selectedValue === 'string' ? selectedValue : '';
 
@@ -197,13 +206,6 @@ export const SelectButton = forwardRef<HTMLElement, SelectButtonProps>(
 			) {
 				const childProps = {
 					value: selectedValue as SelectOptionValue,
-					...( multiple
-						? {
-							onClose: handleOnCloseItem(
-									selectedValue as SelectOptionValue
-							),
-						}
-						: {} ),
 				};
 				renderValue = children( childProps );
 			}
@@ -227,7 +229,7 @@ export const SelectButton = forwardRef<HTMLElement, SelectButtonProps>(
 					{ renderValue as React.ReactNode }
 				</span>
 			);
-		}, [ getValues, disabled ] );
+		}, [ getValues, disabled, multiple, render, children ] );
 
 		const handleOnCloseItem =
 			( value: SelectOptionValue ) =>
@@ -235,9 +237,7 @@ export const SelectButton = forwardRef<HTMLElement, SelectButtonProps>(
 					event?.preventDefault();
 					event?.stopPropagation();
 
-					const selectedValues = [
-						...( ( getValues() as SelectOptionValue[] ) ?? [] ),
-					];
+					const selectedValues = [ ...toValuesArray( getValues() ) ];
 					const selectedIndex = selectedValues.findIndex( ( val ) => {
 						if (
 							val !== null &&
@@ -276,7 +276,7 @@ export const SelectButton = forwardRef<HTMLElement, SelectButtonProps>(
 			}
 
 			const showPlaceholder = multiple
-				? ! ( getValues() as SelectOptionValue[] )?.length
+				? ! toValuesArray( getValues() ).length
 				: ! getValues() && ! searchKeyword;
 
 			return (
@@ -384,9 +384,9 @@ export const SelectButton = forwardRef<HTMLElement, SelectButtonProps>(
 											multiple
 										) {
 											e.preventDefault();
-											const arr =
-												( getValues() as SelectOptionValue[] ) ??
-												[];
+											const arr = toValuesArray(
+												getValues()
+											);
 											if ( arr.length ) {
 												handleOnCloseItem(
 													arr[ arr.length - 1 ]
@@ -456,7 +456,7 @@ export const SelectButton = forwardRef<HTMLElement, SelectButtonProps>(
 
 						{ /* Placeholder */ }
 						{ ( multiple
-							? ! ( getValues() as SelectOptionValue[] )?.length
+							? ! toValuesArray( getValues() ).length
 							: ! getValues() ) && (
 							<div
 								className={ cn(
@@ -1047,7 +1047,7 @@ export function SelectItem( {
 		if ( ! currentValue ) {
 			return false;
 		}
-		return ( currentValue as SelectOptionValue[] ).some( ( val ) => {
+		return toValuesArray( currentValue ).some( ( val ) => {
 			if ( val !== null && value !== null && typeof val === 'object' ) {
 				return (
 					( val as Record<string, unknown> )[ by ] ===
@@ -1056,7 +1056,7 @@ export function SelectItem( {
 			}
 			return val === value;
 		} );
-	}, [ value, getValues ] );
+	}, [ value, getValues, multiple, by ] );
 
 	const isChecked = useMemo( () => {
 		if ( typeof selected === 'boolean' ) {
@@ -1068,7 +1068,7 @@ export function SelectItem( {
 		}
 
 		return indx === selectedIndex;
-	}, [ multipleChecked, selectedIndex, selected ] );
+	}, [ multipleChecked, selectedIndex, selected, multiple ] );
 
 	let itemTabIndex: number | undefined;
 	if ( ! inlineSearch ) {
@@ -1234,9 +1234,10 @@ const SelectComponent = ( {
 		] );
 
 	const handleMultiSelect: OnClick = ( index, newValue ) => {
-		const selectedValues = [
-			...( ( getValues() as SelectOptionValue[] ) ?? [] ),
-		];
+		// getValues() can return a single value here — e.g. `multiple` flipped
+		// to true while a single selection was already made — so normalize
+		// before treating it as a list.
+		const selectedValues = [ ...toValuesArray( getValues() ) ];
 		const valueIndex = selectedValues.findIndex( ( selectedValue ) => {
 			if (
 				selectedValue !== null &&

--- a/src/components/select/utils.ts
+++ b/src/components/select/utils.ts
@@ -1,4 +1,29 @@
 import { type ReactNode, isValidElement } from 'react';
+import type { SelectOptionValue } from './select-types';
+
+/**
+ * Normalize a select value into an array of selected values.
+ *
+ * Multi-select code paths assume an array, but the value can be a single
+ * value when `multiple` is toggled at runtime or when a single value is
+ * passed while `multiple` is true. Wrapping instead of assuming keeps those
+ * paths from throwing on non-iterable values.
+ *
+ * @param {SelectOptionValue | SelectOptionValue[] | null | undefined} value - Current select value.
+ * @return {SelectOptionValue[]} Array of selected values.
+ * @since x.x.x
+ */
+export const toValuesArray = (
+	value: SelectOptionValue | SelectOptionValue[] | null | undefined
+): SelectOptionValue[] => {
+	if ( Array.isArray( value ) ) {
+		return value;
+	}
+	if ( value === null || typeof value === 'undefined' || value === '' ) {
+		return [];
+	}
+	return [ value ];
+};
 
 /**
  * Get text content of a node


### PR DESCRIPTION
Closes #490

## What
- `multiple` mode: dropdown stays open after an option is clicked or toggled via Enter/Space, so several options can be picked without reopening.
- Clicking an already-selected option now deselects it (toggle) without closing.
- Escape and outside click still close the list via Floating UI `useDismiss` (unchanged); focus returns to the trigger through `FloatingFocusManager`.
- Single mode unchanged: closes on select.

## How
`handleMultiSelect` in `select.tsx` no longer calls `setIsOpen(false)` or refocuses the trigger, and the early-return for already-selected values is replaced with a splice (deselect). Checkmarks/badges update live since option checked state derives from `getValues()`.

## Tests
- Updated `MultiSelect` and `InlineSearchMulti` play tests: keep-open assertions after each pick, toggle-deselect without close, Escape closes.
- Full vitest storybook suite: 82 files / 251 tests green.
- Manual E2E in Chrome against Storybook: multi keep-open, toggle-deselect, Escape close, outside-click close, reopen persists selection, single mode closes on select. No console errors.

## Notes
- Stacked on `component-improvements/editor-input` (PR #489) — will retarget automatically when that merges.
- Changelog entry added under 1.8.1.
- `select-atom.stories.tsx` has pre-existing CRLF line endings in HEAD; left untouched to keep the diff clean.